### PR TITLE
Refactor to user mail headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: elixir
+elixir:
+  - 1.2.0
+otp_release:
+  - 18.0
+sudo: false # to use faster container based build environment
+cache:
+  directories:
+    - _build
+    - deps

--- a/lib/mail.ex
+++ b/lib/mail.ex
@@ -1,39 +1,47 @@
 defmodule Mail do
-  defstruct subject: "",
-            body: "",
-            from: "",
-            reply_to: nil,
-            to: [],
-            cc: [],
-            bcc: []
-
-  def put_subject(mail, subject),
-    do: put_in(mail.subject, subject)
+  defstruct body: "",
+            headers: %{}
 
   def put_body(mail, body),
     do: put_in(mail.body, body)
 
-  def put_from(mail, sender),
-    do: put_in(mail.from, sender)
+  def put_header(mail, key, content),
+    do: put_in(mail.headers[key], content)
 
-  def put_reply_to(mail, reply_address),
-    do: put_in(mail.reply_to, reply_address)
+  def put_subject(mail, subject),
+    do: put_header(mail, :subject, subject)
 
   def put_to(mail, recipient) when is_binary(recipient),
     do: put_to(mail, [recipient])
 
   def put_to(mail, recipients) when is_list(recipients),
-    do: put_in(mail.to, mail.to ++ recipients)
+    do: put_header(mail, :to, (mail.headers[:to] || []) ++ recipients)
 
   def put_cc(mail, recipient) when is_binary(recipient),
     do: put_cc(mail, [recipient])
 
   def put_cc(mail, recipients) when is_list(recipients),
-    do: put_in(mail.cc, mail.cc ++ recipients)
+    do: put_header(mail, :cc, (mail.headers[:cc] || []) ++ recipients)
 
   def put_bcc(mail, recipient) when is_binary(recipient),
     do: put_bcc(mail, [recipient])
 
   def put_bcc(mail, recipients) when is_list(recipients),
-    do: put_in(mail.bcc, mail.bcc ++ recipients)
+    do: put_header(mail, :bcc, (mail.headers[:bcc] || []) ++ recipients)
+
+  def put_from(mail, sender),
+    do: put_header(mail, :from, sender)
+
+  def put_reply_to(mail, reply_address),
+    do: put_header(mail, :reply_to, reply_address)
+
+  def put_content_type(mail, content_type),
+    do: put_header(mail, :content_type, content_type)
+
+  def all_recipients(mail) do
+    List.wrap(mail.headers[:to]) ++
+    List.wrap(mail.headers[:cc]) ++
+    List.wrap(mail.headers[:bcc])
+    |> Enum.uniq()
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -7,6 +7,8 @@ defmodule Mail.Mixfile do
      elixir: "~> 1.2",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
+     description: description(),
+     package: package(),
      deps: deps]
   end
 
@@ -15,6 +17,17 @@ defmodule Mail.Mixfile do
   # Type "mix help compile.app" for more information
   def application do
     [applications: [:logger]]
+  end
+
+  def package do
+    [maintainers: ["Brian Cardarella"],
+     licenses: ["MIT"],
+     links: %{"GitHub" => "https://github.com/DockYard/elixir-mail"}
+    ]
+  end
+
+  def description do
+    "Easily build a composable mail message"
   end
 
   # Dependencies can be Hex packages:

--- a/test/mail_test.exs
+++ b/test/mail_test.exs
@@ -2,24 +2,29 @@ defmodule MailTest do
   use ExUnit.Case
   doctest Mail
 
-  test "put_subject" do
-    mail = Mail.put_subject(%Mail{}, "test subject")
-    assert mail.subject == "test subject"
-  end
-
   test "put_body" do
     mail = Mail.put_body(%Mail{}, "test body")
     assert mail.body == "test body"
   end
 
+  test "put_header" do
+    mail = Mail.put_header(%Mail{}, :test, "test content")
+    assert mail.headers.test == "test content"
+  end
+
+  test "put_subject" do
+    mail = Mail.put_subject(%Mail{}, "test subject")
+    assert mail.headers.subject == "test subject"
+  end
+
   test "put_to when single recipient" do
     mail = Mail.put_to(%Mail{}, "user@example.com")
-    assert mail.to == ["user@example.com"]
+    assert mail.headers.to == ["user@example.com"]
   end
 
   test "put_to when multiple recipients" do
     mail = Mail.put_to(%Mail{}, ["one@example.com", "two@example.com"])
-    assert mail.to == ["one@example.com", "two@example.com"]
+    assert mail.headers.to == ["one@example.com", "two@example.com"]
   end
 
   test "composing multiple `to` recipients" do
@@ -27,29 +32,19 @@ defmodule MailTest do
       Mail.put_to(%Mail{}, "user@example.com")
       |> Mail.put_to(["one@example.com", "two@example.com"])
 
-    assert mail.to == ["user@example.com",
-                       "one@example.com",
-                       "two@example.com"]
-  end
-
-  test "put_from" do
-    mail = Mail.put_from(%Mail{}, "user@example.com")
-    assert mail.from == "user@example.com"
-  end
-
-  test "put_reply_to" do
-    mail = Mail.put_reply_to(%Mail{}, "other@example.com")
-    assert mail.reply_to == "other@example.com"
+    assert mail.headers.to == ["user@example.com",
+                               "one@example.com",
+                               "two@example.com"]
   end
 
   test "put_cc when single recipient" do
     mail = Mail.put_cc(%Mail{}, "user@example.com")
-    assert mail.cc == ["user@example.com"]
+    assert mail.headers.cc == ["user@example.com"]
   end
 
   test "put_cc when multiple recipients" do
     mail = Mail.put_cc(%Mail{}, ["one@example.com", "two@example.com"])
-    assert mail.cc == ["one@example.com", "two@example.com"]
+    assert mail.headers.cc == ["one@example.com", "two@example.com"]
   end
 
   test "composing multiple `cc` recipients" do
@@ -57,19 +52,19 @@ defmodule MailTest do
       Mail.put_cc(%Mail{}, "user@example.com")
       |> Mail.put_cc(["one@example.com", "two@example.com"])
 
-    assert mail.cc == ["user@example.com",
-                       "one@example.com",
-                       "two@example.com"]
+    assert mail.headers.cc == ["user@example.com",
+                               "one@example.com",
+                               "two@example.com"]
   end
 
   test "put_bcc when single recipient" do
     mail = Mail.put_bcc(%Mail{}, "user@example.com")
-    assert mail.bcc == ["user@example.com"]
+    assert mail.headers.bcc == ["user@example.com"]
   end
 
   test "put_bcc when multiple recipients" do
     mail = Mail.put_bcc(%Mail{}, ["one@example.com", "two@example.com"])
-    assert mail.bcc == ["one@example.com", "two@example.com"]
+    assert mail.headers.bcc == ["one@example.com", "two@example.com"]
   end
 
   test "composing multiple `bcc` recipients" do
@@ -77,8 +72,38 @@ defmodule MailTest do
       Mail.put_bcc(%Mail{}, "user@example.com")
       |> Mail.put_bcc(["one@example.com", "two@example.com"])
 
-    assert mail.bcc == ["user@example.com",
-                       "one@example.com",
-                       "two@example.com"]
+    assert mail.headers.bcc == ["user@example.com",
+                                "one@example.com",
+                                "two@example.com"]
+  end
+
+  test "put_from" do
+    mail = Mail.put_from(%Mail{}, "user@example.com")
+    assert mail.headers.from == "user@example.com"
+  end
+
+  test "put_reply_to" do
+    mail = Mail.put_reply_to(%Mail{}, "other@example.com")
+    assert mail.headers[:reply_to] == "other@example.com"
+  end
+
+  test "put_content_type" do
+    mail = Mail.put_content_type(%Mail{}, "multipart/mixed")
+    assert mail.headers[:content_type] == "multipart/mixed"
+  end
+
+  test "all_recipients combins :to, :cc, and :bcc" do
+    mail =
+      Mail.put_to(%Mail{}, ["one@example.com", "two@example.com"])
+      |> Mail.put_cc(["three@example.com", "one@example.com"])
+      |> Mail.put_bcc(["four@example.com", "three@example.com"])
+
+    recipients = Mail.all_recipients(mail)
+
+    assert length(recipients) == 4
+    assert Enum.member?(recipients, "one@example.com")
+    assert Enum.member?(recipients, "two@example.com")
+    assert Enum.member?(recipients, "three@example.com")
+    assert Enum.member?(recipients, "four@example.com")
   end
 end


### PR DESCRIPTION
Force data to be set on the header rather than directly on the struct.
This introduces a more verbose way to getting data but is "more
correct".