### PR TITLE
Fixes unused variables warning

### DIFF
--- a/lib/mail.ex
+++ b/lib/mail.ex
@@ -244,7 +244,7 @@ defmodule Mail do
   defp validate_recipients([]), do: nil
   defp validate_recipients([recipient|tail]) do
     case recipient do
-      {name, email} -> validate_recipients(tail)
+      {_name, _email} -> validate_recipients(tail)
       email when is_binary(email) -> validate_recipients(tail)
       other -> raise ArgumentError,
         message: """


### PR DESCRIPTION
Fixes warning during compilation

Before:
```
⟩ rm -rf _build/; mix test
lib/mail.ex:247: warning: variable email is unused
lib/mail.ex:247: warning: variable name is unused
Compiled lib/mail.ex
Generated mail app
Consolidated List.Chars
Consolidated String.Chars
Consolidated Collectable
Consolidated Enumerable
Consolidated IEx.Info
Consolidated Inspect
..........................

Finished in 0.2 seconds (0.2s on load, 0.00s on tests)
26 tests, 0 failures
```

After:
```
⟩ rm -rf _build/; mix test
Compiled lib/mail.ex
Generated mail app
Consolidated List.Chars
Consolidated String.Chars
Consolidated Collectable
Consolidated IEx.Info
Consolidated Enumerable
Consolidated Inspect
..........................

Finished in 0.2 seconds (0.2s on load, 0.00s on tests)
26 tests, 0 failures
```