### PR TITLE
Build mail function

### DIFF
--- a/lib/mail.ex
+++ b/lib/mail.ex
@@ -8,7 +8,8 @@ defmodule Mail do
   Build a mail message with the `Mail` struct
 
       mail =
-        Mail.put_subject(%Mail{}, "How is it going?")
+        Mail.build
+        |> Mail.put_subject("How is it going?")
         |> Mail.put_text("Just checking in")
         |> Mail.put_to("joe@example.com")
         |> Mail.put_from("brian@example.com")
@@ -18,6 +19,14 @@ defmodule Mail do
                        to: ["joe@example.com"],
                        from: "brian@example.com"}}
   """
+
+  @doc """
+  Builds empty mail struct for further composing
+
+      Mail.build()
+  """
+  def build,
+    do: %Mail{}
 
   @doc """
   Add content to the body by mimetype as a key/value pair

--- a/test/mail_test.exs
+++ b/test/mail_test.exs
@@ -147,7 +147,8 @@ defmodule MailTest do
 
   test "all_recipients combins :to, :cc, and :bcc" do
     mail =
-      Mail.put_to(%Mail{}, ["one@example.com", "two@example.com"])
+      Mail.build
+      |> Mail.put_to(["one@example.com", "two@example.com"])
       |> Mail.put_cc(["three@example.com", "one@example.com"])
       |> Mail.put_bcc(["four@example.com", "three@example.com"])
 

--- a/test/mail_test.exs
+++ b/test/mail_test.exs
@@ -2,6 +2,12 @@ defmodule MailTest do
   use ExUnit.Case
   doctest Mail
 
+  # Build
+  test "build" do
+    mail = Mail.build
+    assert mail == %Mail{}
+  end
+
   # Body
 
   test "put_body" do


### PR DESCRIPTION
Adds build function that returns empty Mail struct, thus also hides implementation details how to build the struct (or how to invoke it).

Additionally it looks better. :)

Simple:

```elixir
iex(1)> Mail.build
%Mail{body: %{}, headers: %{}}```