### PR TITLE
Extract test assertions

### DIFF
--- a/test/mail/renderers/rfc_2822_test.exs
+++ b/test/mail/renderers/rfc_2822_test.exs
@@ -1,6 +1,6 @@
 defmodule Mail.Renderers.RFC2822Test do
   use ExUnit.Case
-  import Mail.TestAssertions
+  import Mail.Assertions.RFC2822
 
   test "header - capitalizes and hyphenates keys, joins lists according to spec" do
     header = Mail.Renderers.RFC2822.render_header(:foo_bar, ["abcd", baz_buzz: "qux"])

--- a/test/mail/test_assertions_test.exs
+++ b/test/mail/test_assertions_test.exs
@@ -1,0 +1,88 @@
+defmodule Mail.TestAssertionsTest do
+  use ExUnit.Case
+
+  test "will not raise when two multipart messages are equal" do
+    message1 =
+      Mail.build_multipart()
+      |> Mail.put_subject("Hello")
+      |> Mail.put_to("user@example.com")
+      |> Mail.put_attachment("README.md")
+
+    message2 =
+      Mail.build_multipart()
+      |> Mail.put_subject("Hello")
+      |> Mail.put_to("user@example.com")
+      |> Mail.put_attachment("README.md")
+
+    Mail.TestAssertions.compare(message1, message2)
+  end
+
+  test "will not raise when two multipart messages have different boundaries" do
+    message1 =
+      Mail.build_multipart()
+      |> Mail.put_subject("Hello")
+      |> Mail.put_to("user@example.com")
+      |> Mail.put_attachment("README.md")
+      |> Mail.Message.put_content_type("multipart/alternative")
+      |> Mail.Message.put_boundary("foobar")
+
+    message2 =
+      Mail.build_multipart()
+      |> Mail.put_subject("Hello")
+      |> Mail.put_to("user@example.com")
+      |> Mail.put_attachment("README.md")
+      |> Mail.Message.put_content_type("multipart/alternative")
+      |> Mail.Message.put_boundary("bazqux")
+
+    Mail.TestAssertions.compare(message1, message2)
+  end
+
+  test "will raise when a multipart message and a singlepart message are compared" do
+    assert_raise ExUnit.AssertionError, "one message is multipart, the other is not", fn ->
+      Mail.TestAssertions.compare(Mail.build(), Mail.build_multipart())  
+    end
+  end
+
+  test "will raise when two multipart messages have different number of parts" do
+    message1 =
+      Mail.build_multipart()
+      |> Mail.put_text("Some text")
+      |> Mail.put_html("<h1>Some HTML</h1>")
+
+    message2 =
+      Mail.build_multipart()
+      |> Mail.put_text("Some text")
+
+    assert_raise ExUnit.AssertionError, "actual and expected must have equal number of parts", fn ->
+      Mail.TestAssertions.compare(message1, message2)
+    end
+  end
+
+  test "will raise when the bodies differ" do
+    message1 =
+      Mail.build()
+      |> Mail.put_text("Some text")
+
+    message2 =
+      Mail.build()
+      |> Mail.put_text("Some other text")
+
+    assert_raise ExUnit.AssertionError, fn ->
+      Mail.TestAssertions.compare(message1, message2)
+    end
+  end
+
+  test "will raise when headers differ" do
+    message1 =
+      Mail.build()
+      |> Mail.put_subject("Test subject")
+
+    message2 =
+      Mail.build()
+      |> Mail.put_subject("Other subject")
+
+    assert_raise ExUnit.AssertionError, "header key `subject` is not equal", fn ->
+      Mail.TestAssertions.compare(message1, message2)
+    end
+  end
+end

--- a/test/support/rfc2822_assertions.ex
+++ b/test/support/rfc2822_assertions.ex
@@ -1,0 +1,13 @@
+defmodule Mail.Assertions.RFC2822 do
+  @doc """
+  Compares to messages to ensure they are equal
+
+  Will ignore boundary values.
+  """
+  def assert_rfc2822_equal(actual, expected) do
+    actual = Mail.Parsers.RFC2822.parse(actual)
+    expected = Mail.Parsers.RFC2822.parse(expected)
+
+    Mail.TestAssertions.compare(actual, expected)
+  end
+end


### PR DESCRIPTION
The assertion primitives have been extracted into Mail.TestAssertions

These can be used by other libraries that want to write their own
assertion wrapper for parsers.