### PR TITLE
Update Base64 encoder to encode and parse w newlines every 76 characters

### DIFF
--- a/lib/mail/encoders/base64.ex
+++ b/lib/mail/encoders/base64.ex
@@ -1,7 +1,23 @@
 defmodule Mail.Encoders.Base64 do
+  @moduledoc """
+  Encodes/decodes base64 strings according to RFC 2045 which requires line
+  lengths of less than 76 characters and illegal characters to be removed
+  during parsing.
+
+  See the following links for reference:
+  - <https://www.ietf.org/rfc/rfc2045.txt>
+  - <http://stackoverflow.com/questions/25710599/content-transfer-encoding-7bit-or-8-bit>
+  - <http://stackoverflow.com/questions/13301708/base64-encode-length-parameter>
+  """
+
   def encode(string),
-    do: Base.encode64(string)
+    do: add_line_breaks(Base.encode64(string))
 
   def decode(string),
-    do: Base.decode64!(string)
+    do: :base64.mime_decode(string)
+
+  defp add_line_breaks(<< head :: binary-size(76), tail :: binary >>),
+    do: head <> "\r\n" <> add_line_breaks(tail)
+  defp add_line_breaks(tail), do: tail <> "\r\n"
+
 end

--- a/test/mail/encoders/base64_test.exs
+++ b/test/mail/encoders/base64_test.exs
@@ -1,0 +1,18 @@
+defmodule Mail.Encoders.Base64Test do
+  use ExUnit.Case
+
+  test "parses data with line feeds" do
+    base64_sample = "SGVsbG8gd29ybGQhIEhlbGxvIHdvcmxkISBIZWxsbyB3b3JsZCEgSGVsbG8g\r\nd29ybGQhIEhlbGxvIHdvcmxkISBIZWxsbyB3b3JsZCE=\r\n"
+    decoded = Mail.Encoders.Base64.decode(base64_sample)
+
+    assert decoded == "Hello world! Hello world! Hello world! Hello world! Hello world! Hello world!"
+  end
+
+
+  test "encodes data with line feeds" do
+    message = "Hello world! Hello world! Hello world! Hello world! Hello world! Hello world! Hello world! Hello world! Hello world!"
+    encoded = Mail.Encoders.Base64.encode(message)
+
+    assert encoded == "SGVsbG8gd29ybGQhIEhlbGxvIHdvcmxkISBIZWxsbyB3b3JsZCEgSGVsbG8gd29ybGQhIEhlbGxv\r\nIHdvcmxkISBIZWxsbyB3b3JsZCEgSGVsbG8gd29ybGQhIEhlbGxvIHdvcmxkISBIZWxsbyB3b3Js\r\nZCE=\r\n"
+  end
+end


### PR DESCRIPTION
I believe this update is inline with RFC 2045. Here are some links I found describing this encoding:
http://stackoverflow.com/questions/25710599/content-transfer-encoding-7bit-or-8-bit
http://stackoverflow.com/questions/13301708/base64-encode-length-parameter