### PR TITLE
RFC2822 Renderer will properly encode body

### DIFF
--- a/lib/mail/renderers/rfc_2822.ex
+++ b/lib/mail/renderers/rfc_2822.ex
@@ -44,7 +44,8 @@ defmodule Mail.Renderers.RFC2822 do
     "#{headers}\n\n#{boundary}\n#{parts}\n#{boundary}--"
   end
   def render_part(%Mail.Message{} = message) do
-    "#{render_headers(message.headers, @blacklisted_headers)}\n\n#{message.body}"
+    encoded_body = encode(message.body, message)
+    "#{render_headers(message.headers, @blacklisted_headers)}\n\n#{encoded_body}"
   end
 
   def render_parts(parts) when is_list(parts),
@@ -132,4 +133,8 @@ defmodule Mail.Renderers.RFC2822 do
     end
   end
   defp reorganize(%Mail.Message{} = message), do: message
+
+  defp encode(body, message) do
+    Mail.Encoder.encode(body, get_in(message.headers, [:content_transfer_encoding]))
+  end
 end

--- a/test/mail/renderers/rfc_2822_test.exs
+++ b/test/mail/renderers/rfc_2822_test.exs
@@ -87,4 +87,19 @@ defmodule Mail.Renderers.RFC2822Test do
 
     refute Map.has_key?(message.headers, :bcc)
   end
+
+  test "properly encodes body based upon Content-Transfer-Encoding value" do
+    file = File.read!("README.md")
+
+    message =
+      Mail.build()
+      |> Mail.Message.put_header(:content_transfer_encoding, :base64)
+      |> Mail.put_text(file)
+
+    result = Mail.Renderers.RFC2822.render(message)
+
+    encoded_file = Mail.Encoder.encode(file, :base64)
+
+    assert result =~ encoded_file
+  end
 end


### PR DESCRIPTION
Message bodies will be encoded according to their
Content-Transfer-Encoding value. Missing values will default to the
Identity encoder.