### PR TITLE
Initial commit of quoted printable encoder

### DIFF
--- a/lib/mail/encoders/quoted_printable.ex
+++ b/lib/mail/encoders/quoted_printable.ex
@@ -51,6 +51,7 @@ defmodule Mail.Encoders.QuotedPrintable do
   defp emit_escaped_char(char, line_length, maximum) do
     escaped = "=" <> Base.encode16(<<char>>)
     escaped_length = String.length(escaped)
+
     if line_length + escaped_length <= maximum do
       {escaped, line_length + escaped_length}
     else
@@ -92,6 +93,7 @@ defmodule Mail.Encoders.QuotedPrintable do
   defp decode_escaped_char(?\r, ?\n), do: ""
   defp decode_escaped_char(char1, char2) do
     chars = <<char1>> <> <<char2>>
+
     case Base.decode16(chars, case: :mixed) do
       {:ok, decoded} -> decoded
       :error -> "=" <> chars

--- a/lib/mail/encoders/quoted_printable.ex
+++ b/lib/mail/encoders/quoted_printable.ex
@@ -1,0 +1,96 @@
+defmodule Mail.Encoders.QuotedPrintable do
+  @moduledoc """
+  Encodes/decodes quoted-printable strings according to RFC 2045.
+
+  See the following links for reference:
+  - <https://tools.ietf.org/html/rfc2045#section-6.7>
+  """
+
+  @new_line "=\r\n"
+  @max_length 76
+
+  @doc """
+  Encodes a string into a quoted-printable encoded string.
+  ## Examples
+      iex> Mail.Encoders.QuotedPrintable.encode("façade")
+      "fa=C3=A7ade"
+  """
+  def encode(string), do: do_encode(string, "", 0)
+  defp do_encode(<<>>, acc, _), do: acc
+  defp do_encode(<<h, t::binary>>, acc, line_length) do
+    {encoding, line_length} = encode_char(h, line_length, String.length(t))
+    do_encode(t, acc <> encoding, line_length)
+  end
+
+  # Encode ASCII characters in range 0x20..0x3C.
+  defp encode_char(char, line_length, _) when char in ?!..?< do
+    emit_raw_char(char, line_length)
+  end
+
+  # Encode ASCII characters in range 0x3E..0x7E.
+  defp encode_char(char, line_length, _) when char in ?>..?~ do
+    emit_raw_char(char, line_length)
+  end
+
+  # Encode ASCII tab and space characters.
+  defp encode_char(char, line_length, remaining) when char in [?\t, ?\s] do
+    if remaining > 0 do
+      emit_raw_char(char, line_length)
+    else
+      emit_escaped_char(char, line_length, @max_length)
+    end
+  end
+
+  # Encode all other characters.
+  defp encode_char(char, line_length, _) do
+    emit_escaped_char(char, line_length, @max_length - 1)
+  end
+
+  defp emit_escaped_char(char, line_length, maximum) do
+    escaped = "=" <> Base.encode16(<<char>>)
+    escaped_length = String.length(escaped)
+    if line_length + escaped_length <= maximum do
+      {escaped, line_length + escaped_length}
+    else
+      {@new_line <> escaped, escaped_length}
+    end
+  end
+
+  defp emit_raw_char(char, line_length) do
+    if line_length < @max_length - 1 do
+      {<<char>>, line_length + 1}
+    else
+      {@new_line <> <<char>>, 1}
+    end
+  end
+
+  @doc """
+  Decodes a quoted-printable encoded string.
+  ## Examples
+      iex> Mail.Encoders.QuotedPrintable.decode("fa=C3=A7ade")
+      "façade"
+  """
+  def decode(string), do: do_decode(string, "")
+  defp do_decode(<<>>, acc), do: acc
+  defp do_decode(<<h, t::binary>>, acc) do
+    {decoded, tail} = decode_char(h, t)
+    do_decode(tail, acc <> decoded)
+  end
+
+  defp decode_char(?=, <<c1, c2, t::binary>>) do
+    {decode_escaped_char(c1, c2), t}
+  end
+
+  defp decode_char(char, tail) do
+    {<<char>>, tail}
+  end
+
+  defp decode_escaped_char(?\r, ?\n), do: ""
+  defp decode_escaped_char(c1, c2) do
+    chars = <<c1>> <> <<c2>>
+    case Base.decode16(chars, case: :mixed) do
+      {:ok, decoded} -> decoded
+      :error -> "=" <> chars
+    end
+  end
+end

--- a/lib/mail/encoders/quoted_printable.ex
+++ b/lib/mail/encoders/quoted_printable.ex
@@ -12,7 +12,7 @@ defmodule Mail.Encoders.QuotedPrintable do
   @doc """
   Encodes a string into a quoted-printable encoded string.
   ## Examples
-      iex> Mail.Encoders.QuotedPrintable.encode("façade")
+      Mail.Encoders.QuotedPrintable.encode("façade")
       "fa=C3=A7ade"
   """
   def encode(string), do: do_encode(string, "", 0)
@@ -67,7 +67,7 @@ defmodule Mail.Encoders.QuotedPrintable do
   @doc """
   Decodes a quoted-printable encoded string.
   ## Examples
-      iex> Mail.Encoders.QuotedPrintable.decode("fa=C3=A7ade")
+      Mail.Encoders.QuotedPrintable.decode("fa=C3=A7ade")
       "façade"
   """
   def decode(string), do: do_decode(string, "")

--- a/lib/mail/encoders/quoted_printable.ex
+++ b/lib/mail/encoders/quoted_printable.ex
@@ -11,7 +11,9 @@ defmodule Mail.Encoders.QuotedPrintable do
 
   @doc """
   Encodes a string into a quoted-printable encoded string.
+
   ## Examples
+
       Mail.Encoders.QuotedPrintable.encode("façade")
       "fa=C3=A7ade"
   """
@@ -66,7 +68,9 @@ defmodule Mail.Encoders.QuotedPrintable do
 
   @doc """
   Decodes a quoted-printable encoded string.
+
   ## Examples
+
       Mail.Encoders.QuotedPrintable.decode("fa=C3=A7ade")
       "façade"
   """

--- a/test/mail/encoders/quoted_printable_test.exs
+++ b/test/mail/encoders/quoted_printable_test.exs
@@ -1,0 +1,185 @@
+defmodule Mail.Encoders.QuotedPrintableTest do
+  use ExUnit.Case
+  import Mail.Encoders.QuotedPrintable
+
+  test "encodes empty string" do
+    assert encode("") == ""
+  end
+
+  test "encodes safe characters as themselves" do
+    ascii_lower = "abcdefghijklmnopqrstuvwxyz"
+    assert encode(ascii_lower) == ascii_lower
+
+    ascii_upper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    assert encode(ascii_upper) == ascii_upper
+
+    ascii_symbols = "!\"#$%&\'()*+,-./0123456789:;<>?@[\\]^_`{|}~"
+    assert encode(ascii_symbols) == ascii_symbols
+  end
+
+  test "encodes equal sign" do
+    assert encode("hello=goodbye") == "hello=3Dgoodbye"
+  end
+
+  test "encodes trailing space" do
+    assert encode("hello ") == "hello=20"
+  end
+
+  test "encodes trailing tab" do
+    assert encode("hello\t") == "hello=09"
+  end
+
+  test "encodes <CR><LF>" do
+    assert encode("foo\r\nbar") == "foo=0D=0Abar"
+  end
+
+  test "encodes UTF-8 characters" do
+    assert encode("façade") == "fa=C3=A7ade"
+  end
+
+  test "encodes escaped UTF-8 characters" do
+    assert encode("fa\u00E7ade") == "fa=C3=A7ade"
+  end
+
+  test "encodes lines longer than 76 characters using soft line breaks" do
+    message  = """
+    Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy \
+    nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat. Ut \
+    wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper \
+    suscipit lobortis nisl ut aliquip ex ea commodo consequat.\
+    """
+    encoding = """
+    Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy =\r\n\
+    nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat. Ut wi=\r\n\
+    si enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lo=\r\n\
+    bortis nisl ut aliquip ex ea commodo consequat.\
+    """
+    assert encode(message) == encoding
+  end
+
+  test "encodes 73 chars ending with an equal sign" do
+    message  = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx="
+    encoding = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx=3D"
+    assert encode(message) == encoding
+  end
+
+  test "encodes 74 chars ending with an equal sign" do
+    message  = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx="
+    encoding = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx=\r\n=3D"
+    assert encode(message) == encoding
+  end
+
+  test "encodes 75 chars ending with an equal sign" do
+    message  = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx="
+    encoding = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx=\r\n=3D"
+    assert encode(message) == encoding
+  end
+
+  test "encodes 76 chars ending with an equal sign" do
+    message  = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx="
+    encoding = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx=\r\n=3D"
+    assert encode(message) == encoding
+  end
+
+  test "encodes 77 chars ending with an equal sign" do
+    message  = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx="
+    encoding = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx=\r\nx=3D"
+    assert encode(message) == encoding
+  end
+
+  test "encodes 73 chars ending with a space" do
+    message  = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx "
+    encoding = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx=20"
+    assert encode(message) == encoding
+  end
+
+  test "encodes 74 chars ending with a space" do
+    message  = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx "
+    encoding = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx=20"
+    assert encode(message) == encoding
+  end
+
+  test "encodes 75 chars ending with a space" do
+    message  = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx "
+    encoding = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx=\r\n=20"
+    assert encode(message) == encoding
+  end
+
+  test "encodes 76 chars ending with a space" do
+    message  = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx "
+    encoding = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx=\r\n=20"
+    assert encode(message) == encoding
+  end
+
+  test "encodes 77 chars ending with a space" do
+    message  = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx "
+    encoding = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx=\r\nx=20"
+    assert encode(message) == encoding
+  end
+
+  test "decodes empty string" do
+    assert decode("") == ""
+  end
+
+  test "decodes safe characters as themselves" do
+    ascii_lower = "abcdefghijklmnopqrstuvwxyz"
+    assert decode(ascii_lower) == ascii_lower
+
+    ascii_upper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    assert decode(ascii_upper) == ascii_upper
+
+    ascii_symbols = "!\"#$%&\'()*+,-./0123456789:;<>?@[\\]^_`{|}~"
+    assert decode(ascii_symbols) == ascii_symbols
+  end
+
+  test "decodes equal sign" do
+    assert decode("hello=3Dgoodbye") == "hello=goodbye"
+  end
+
+  test "decodes UTF-8 characters" do
+    assert decode("fa=C3=A7ade") == "façade"
+  end
+
+  test "decodes <CR><LF>" do
+    assert decode("foo=0D=0Abar") == "foo\r\nbar"
+  end
+
+  test "decodes hard new lines" do
+    assert decode("foo\nbar") == "foo\nbar"
+  end
+
+  test "decodes soft line breaks" do
+    encoding = "Now's the time =\r\nfor all folk to come=\r\n to the aid of their country."
+    decoding = "Now's the time for all folk to come to the aid of their country."
+    assert decode(encoding) == decoding
+  end
+
+  test "decodes lines longer than 76 characters" do
+    encoding = """
+    Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy =\r\n\
+    nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat. Ut wi=\r\n\
+    si enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lo=\r\n\
+    bortis nisl ut aliquip ex ea commodo consequat.\
+    """
+    decoding  = """
+    Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy \
+    nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat. Ut \
+    wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper \
+    suscipit lobortis nisl ut aliquip ex ea commodo consequat.\
+    """
+    assert decode(encoding) == decoding
+  end
+
+  test "decodes lowercase case escape sequences as if uppercase per RFC" do
+    assert decode("hello=3d") == "hello="
+  end
+
+  test "decodes illegal escape sequences by returning them unaltered per RFC" do
+    assert decode("foo=") == "foo="
+    assert decode("foo=A") == "foo=A"
+    assert decode("foo=Ax") == "foo=Ax"
+    assert decode("foo=Ax=xy") == "foo=Ax=xy"
+    assert decode("foo=XY") == "foo=XY"
+    assert decode("foo=X") == "foo=X"
+  end
+end

--- a/test/mail/encoders/quoted_printable_test.exs
+++ b/test/mail/encoders/quoted_printable_test.exs
@@ -1,44 +1,43 @@
 defmodule Mail.Encoders.QuotedPrintableTest do
   use ExUnit.Case
-  import Mail.Encoders.QuotedPrintable
 
   test "encodes empty string" do
-    assert encode("") == ""
+    assert Mail.Encoders.QuotedPrintable.encode("") == ""
   end
 
   test "encodes safe characters as themselves" do
     ascii_lower = "abcdefghijklmnopqrstuvwxyz"
-    assert encode(ascii_lower) == ascii_lower
+    assert Mail.Encoders.QuotedPrintable.encode(ascii_lower) == ascii_lower
 
     ascii_upper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-    assert encode(ascii_upper) == ascii_upper
+    assert Mail.Encoders.QuotedPrintable.encode(ascii_upper) == ascii_upper
 
     ascii_symbols = "!\"#$%&\'()*+,-./0123456789:;<>?@[\\]^_`{|}~"
-    assert encode(ascii_symbols) == ascii_symbols
+    assert Mail.Encoders.QuotedPrintable.encode(ascii_symbols) == ascii_symbols
   end
 
   test "encodes equal sign" do
-    assert encode("hello=goodbye") == "hello=3Dgoodbye"
+    assert Mail.Encoders.QuotedPrintable.encode("hello=goodbye") == "hello=3Dgoodbye"
   end
 
   test "encodes trailing space" do
-    assert encode("hello ") == "hello=20"
+    assert Mail.Encoders.QuotedPrintable.encode("hello ") == "hello=20"
   end
 
   test "encodes trailing tab" do
-    assert encode("hello\t") == "hello=09"
+    assert Mail.Encoders.QuotedPrintable.encode("hello\t") == "hello=09"
   end
 
   test "encodes <CR><LF>" do
-    assert encode("foo\r\nbar") == "foo=0D=0Abar"
+    assert Mail.Encoders.QuotedPrintable.encode("foo\r\nbar") == "foo=0D=0Abar"
   end
 
   test "encodes UTF-8 characters" do
-    assert encode("façade") == "fa=C3=A7ade"
+    assert Mail.Encoders.QuotedPrintable.encode("façade") == "fa=C3=A7ade"
   end
 
   test "encodes escaped UTF-8 characters" do
-    assert encode("fa\u00E7ade") == "fa=C3=A7ade"
+    assert Mail.Encoders.QuotedPrintable.encode("fa\u00E7ade") == "fa=C3=A7ade"
   end
 
   test "encodes lines longer than 76 characters using soft line breaks" do
@@ -54,104 +53,104 @@ defmodule Mail.Encoders.QuotedPrintableTest do
     si enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lo=\r\n\
     bortis nisl ut aliquip ex ea commodo consequat.\
     """
-    assert encode(message) == encoding
+    assert Mail.Encoders.QuotedPrintable.encode(message) == encoding
   end
 
   test "encodes 73 chars ending with an equal sign" do
     message  = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx="
     encoding = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx=3D"
-    assert encode(message) == encoding
+    assert Mail.Encoders.QuotedPrintable.encode(message) == encoding
   end
 
   test "encodes 74 chars ending with an equal sign" do
     message  = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx="
     encoding = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx=\r\n=3D"
-    assert encode(message) == encoding
+    assert Mail.Encoders.QuotedPrintable.encode(message) == encoding
   end
 
   test "encodes 75 chars ending with an equal sign" do
     message  = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx="
     encoding = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx=\r\n=3D"
-    assert encode(message) == encoding
+    assert Mail.Encoders.QuotedPrintable.encode(message) == encoding
   end
 
   test "encodes 76 chars ending with an equal sign" do
     message  = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx="
     encoding = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx=\r\n=3D"
-    assert encode(message) == encoding
+    assert Mail.Encoders.QuotedPrintable.encode(message) == encoding
   end
 
   test "encodes 77 chars ending with an equal sign" do
     message  = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx="
     encoding = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx=\r\nx=3D"
-    assert encode(message) == encoding
+    assert Mail.Encoders.QuotedPrintable.encode(message) == encoding
   end
 
   test "encodes 73 chars ending with a space" do
     message  = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx "
     encoding = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx=20"
-    assert encode(message) == encoding
+    assert Mail.Encoders.QuotedPrintable.encode(message) == encoding
   end
 
   test "encodes 74 chars ending with a space" do
     message  = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx "
     encoding = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx=20"
-    assert encode(message) == encoding
+    assert Mail.Encoders.QuotedPrintable.encode(message) == encoding
   end
 
   test "encodes 75 chars ending with a space" do
     message  = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx "
     encoding = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx=\r\n=20"
-    assert encode(message) == encoding
+    assert Mail.Encoders.QuotedPrintable.encode(message) == encoding
   end
 
   test "encodes 76 chars ending with a space" do
     message  = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx "
     encoding = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx=\r\n=20"
-    assert encode(message) == encoding
+    assert Mail.Encoders.QuotedPrintable.encode(message) == encoding
   end
 
   test "encodes 77 chars ending with a space" do
     message  = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx "
     encoding = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx=\r\nx=20"
-    assert encode(message) == encoding
+    assert Mail.Encoders.QuotedPrintable.encode(message) == encoding
   end
 
   test "decodes empty string" do
-    assert decode("") == ""
+    assert Mail.Encoders.QuotedPrintable.decode("") == ""
   end
 
   test "decodes safe characters as themselves" do
     ascii_lower = "abcdefghijklmnopqrstuvwxyz"
-    assert decode(ascii_lower) == ascii_lower
+    assert Mail.Encoders.QuotedPrintable.decode(ascii_lower) == ascii_lower
 
     ascii_upper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-    assert decode(ascii_upper) == ascii_upper
+    assert Mail.Encoders.QuotedPrintable.decode(ascii_upper) == ascii_upper
 
     ascii_symbols = "!\"#$%&\'()*+,-./0123456789:;<>?@[\\]^_`{|}~"
-    assert decode(ascii_symbols) == ascii_symbols
+    assert Mail.Encoders.QuotedPrintable.decode(ascii_symbols) == ascii_symbols
   end
 
   test "decodes equal sign" do
-    assert decode("hello=3Dgoodbye") == "hello=goodbye"
+    assert Mail.Encoders.QuotedPrintable.decode("hello=3Dgoodbye") == "hello=goodbye"
   end
 
   test "decodes UTF-8 characters" do
-    assert decode("fa=C3=A7ade") == "façade"
+    assert Mail.Encoders.QuotedPrintable.decode("fa=C3=A7ade") == "façade"
   end
 
   test "decodes <CR><LF>" do
-    assert decode("foo=0D=0Abar") == "foo\r\nbar"
+    assert Mail.Encoders.QuotedPrintable.decode("foo=0D=0Abar") == "foo\r\nbar"
   end
 
   test "decodes hard new lines" do
-    assert decode("foo\nbar") == "foo\nbar"
+    assert Mail.Encoders.QuotedPrintable.decode("foo\nbar") == "foo\nbar"
   end
 
   test "decodes soft line breaks" do
     encoding = "Now's the time =\r\nfor all folk to come=\r\n to the aid of their country."
     decoding = "Now's the time for all folk to come to the aid of their country."
-    assert decode(encoding) == decoding
+    assert Mail.Encoders.QuotedPrintable.decode(encoding) == decoding
   end
 
   test "decodes lines longer than 76 characters" do
@@ -167,19 +166,19 @@ defmodule Mail.Encoders.QuotedPrintableTest do
     wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper \
     suscipit lobortis nisl ut aliquip ex ea commodo consequat.\
     """
-    assert decode(encoding) == decoding
+    assert Mail.Encoders.QuotedPrintable.decode(encoding) == decoding
   end
 
   test "decodes lowercase case escape sequences as if uppercase per RFC" do
-    assert decode("hello=3d") == "hello="
+    assert Mail.Encoders.QuotedPrintable.decode("hello=3d") == "hello="
   end
 
   test "decodes illegal escape sequences by returning them unaltered per RFC" do
-    assert decode("foo=") == "foo="
-    assert decode("foo=A") == "foo=A"
-    assert decode("foo=Ax") == "foo=Ax"
-    assert decode("foo=Ax=xy") == "foo=Ax=xy"
-    assert decode("foo=XY") == "foo=XY"
-    assert decode("foo=X") == "foo=X"
+    assert Mail.Encoders.QuotedPrintable.decode("foo=") == "foo="
+    assert Mail.Encoders.QuotedPrintable.decode("foo=A") == "foo=A"
+    assert Mail.Encoders.QuotedPrintable.decode("foo=Ax") == "foo=Ax"
+    assert Mail.Encoders.QuotedPrintable.decode("foo=Ax=xy") == "foo=Ax=xy"
+    assert Mail.Encoders.QuotedPrintable.decode("foo=XY") == "foo=XY"
+    assert Mail.Encoders.QuotedPrintable.decode("foo=X") == "foo=X"
   end
 end


### PR DESCRIPTION
Hey Brain, here's an implementation of the quoted-printable encoder. I'm fairly new to Elixir, so please let me know where the code can be improved (or isn't idiomatic). The tests are pretty exhaustive and malformed input is handled per the RFC. Thanks.