### PR TITLE
Initial commit of 7-bit encoder

### DIFF
--- a/lib/mail/encoders/seven_bit.ex
+++ b/lib/mail/encoders/seven_bit.ex
@@ -1,0 +1,48 @@
+defmodule Mail.Encoders.SevenBit do
+  @moduledoc """
+  Encodes/decodes 7-bit strings according to RFC 2045.
+
+  See the following link for reference:
+  - <https://tools.ietf.org/html/rfc2045#section-2.7>
+  """
+
+  @new_line "\r\n"
+  @wrap_length 998
+  @valid_chars 1..127
+
+  @doc """
+  Encodes a string into a 7-bit encoded string.
+
+  Raises if any character isn't in the 7-bit ASCII range 1..127.
+  """
+  def encode(string), do: do_encode(string, "", 0)
+  defp do_encode(<<>>, acc, _line_length), do: acc
+  defp do_encode(<<head, tail::binary>>, acc, line_length) do
+    {encoding, line_length} = emit_char(head, line_length)
+    do_encode(tail, acc <> encoding, line_length)
+  end
+
+  defp emit_char(char, line_length) when char in @valid_chars do
+    if line_length < @wrap_length do
+      {<<char>>, line_length + 1}
+    else
+      {@new_line <> <<char>>, 1}
+    end
+  end
+  defp emit_char(char, _line_length) do
+    raise ArgumentError, message: "invalid character: #{char}"
+  end
+
+  @doc """
+  Decodes a 7-bit encoded string.
+  """
+  def decode(string), do: do_decode(string, "")
+  defp do_decode(<<>>, acc), do: acc
+  defp do_decode(<<head, tail::binary>>, acc) do
+    {decoded, tail} = decode_char(head, tail)
+    do_decode(tail, acc <> decoded)
+  end
+
+  defp decode_char(?\r, <<?\n, tail::binary>>), do: {"", tail}
+  defp decode_char(char, <<tail::binary>>), do: {<<char>>, tail}
+end

--- a/test/mail/encoders/seven_bit_test.exs
+++ b/test/mail/encoders/seven_bit_test.exs
@@ -1,0 +1,36 @@
+defmodule Mail.Encoders.SevenBitTest do
+  use ExUnit.Case
+
+  test "encode handles empty strings" do
+    assert Mail.Encoders.SevenBit.encode("") == ""
+  end
+
+  test "encode wraps lines longer than 1000 characters" do
+    message = String.duplicate("-", 2000)
+    encoding = Mail.Encoders.SevenBit.encode(message)
+    assert binary_part(encoding, 998, 2) == "\r\n"
+    assert binary_part(encoding, 1998, 2) == "\r\n"
+    assert byte_size(encoding) == 2004
+  end
+
+  test "encode raises if any character isn't 7-bit ASCII" do
+    assert_raise ArgumentError, fn ->
+      Mail.Encoders.SevenBit.encode("hełło")
+    end
+  end
+
+  test "encode raises if any character is <NUL>" do
+    assert_raise ArgumentError, fn ->
+      Mail.Encoders.SevenBit.encode("\0")
+    end
+  end
+
+  test "decode handles empty strings" do
+    assert Mail.Encoders.SevenBit.decode("") == ""
+  end
+
+  test "decode removes <CR><LF> pairs" do
+    message = "This is a \r\ntest\r\n"
+    assert Mail.Encoders.SevenBit.decode(message) == "This is a test"
+  end
+end


### PR DESCRIPTION
Per RFC 2045, 7-bit encoding is less an encoding and more a guarantee. It's a guarantee that all data is ASCII with only the lower 7 bits being used for each character, and having no line longer than 1,000 characters (carriage return and line feed characters can only occur as pairs to limit the line length to 1,000 characters, including themselves).

Since there isn't a way to "encode" or "fix" illegal characters, `Mail.Encoders.SevenBit.encode` will raise an `ArgumentError` if any character is outside the valid 7-bit ASCII range 1..127.

In general, I prefer not to raise exceptions, but in this case it's really the only option. Functions that call `Mail.Encoders.SevenBit.encode` should catch `ArgumentError` and fallback to using `Mail.Encoders.Base64.encode`.