### PR TITLE
Implement 8-bit encoder

### DIFF
--- a/lib/mail/encoders/eight_bit.ex
+++ b/lib/mail/encoders/eight_bit.ex
@@ -1,0 +1,47 @@
+defmodule Mail.Encoders.EightBit do
+  @moduledoc """
+  Encodes/decodes 8-bit strings according to RFC 2045.
+
+  See the following link for reference:
+  - <https://tools.ietf.org/html/rfc2045#section-2.8>
+  """
+
+  @new_line "\r\n"
+  @wrap_length 998
+
+  @doc """
+  Encodes a string into an 8-bit encoded string.
+
+  Raises if any character is <NUL> "\0".
+  """
+  def encode(string), do: do_encode(string, "", 0)
+  defp do_encode(<<>>, acc, _line_length), do: acc
+  defp do_encode(<<head, tail::binary>>, acc, line_length) do
+    {encoding, line_length} = emit_char(head, line_length)
+    do_encode(tail, acc <> encoding, line_length)
+  end
+
+  defp emit_char(?\0, _line_length) do
+    raise ArgumentError, message: "illegal NUL character"
+  end
+  defp emit_char(char, line_length) do
+    if line_length < @wrap_length do
+      {<<char>>, line_length + 1}
+    else
+      {@new_line <> <<char>>, 1}
+    end
+  end
+
+  @doc """
+  Decodes an 8-bit encoded string.
+  """
+  def decode(string), do: do_decode(string, "")
+  defp do_decode(<<>>, acc), do: acc
+  defp do_decode(<<head, tail::binary>>, acc) do
+    {decoded, tail} = decode_char(head, tail)
+    do_decode(tail, acc <> decoded)
+  end
+
+  defp decode_char(?\r, <<?\n, tail::binary>>), do: {"", tail}
+  defp decode_char(char, <<tail::binary>>), do: {<<char>>, tail}
+end

--- a/test/mail/encoders/eight_bit_test.exs
+++ b/test/mail/encoders/eight_bit_test.exs
@@ -1,0 +1,30 @@
+defmodule Mail.Encoders.EightBitTest do
+  use ExUnit.Case
+
+  test "encode handles empty strings" do
+    assert Mail.Encoders.EightBit.encode("") == ""
+  end
+
+  test "encode wraps lines longer than 1000 characters" do
+    message = String.duplicate("-", 2000)
+    encoding = Mail.Encoders.EightBit.encode(message)
+    assert binary_part(encoding, 998, 2) == "\r\n"
+    assert binary_part(encoding, 1998, 2) == "\r\n"
+    assert byte_size(encoding) == 2004
+  end
+
+  test "encode raises if any character is <NUL>" do
+    assert_raise ArgumentError, fn ->
+      Mail.Encoders.EightBit.encode("\0")
+    end
+  end
+
+  test "decode handles empty strings" do
+    assert Mail.Encoders.EightBit.decode("") == ""
+  end
+
+  test "decode removes <CR><LF> pairs" do
+    message = "This is a \r\ntest\r\n"
+    assert Mail.Encoders.EightBit.decode(message) == "This is a test"
+  end
+end


### PR DESCRIPTION
Hey Brain, here's an implementation of the 8-bit encoder. Per RFC 2045, lines cannot be longer than 1,000 characters and the  `<NUL>` character is prohibited. `Mail.Encoders.EightBit.encode` will raise an `ArgumentError` if a `<NUL>` character is encountered. Functions that call `Mail.Encoders.EightBit.encode` should therefore catch `ArgumentError` and fallback to using `Mail.Encoders.Base64.encode`.