### PR TITLE
Binary encoder implementation

### DIFF
--- a/lib/mail/encoder.ex
+++ b/lib/mail/encoder.ex
@@ -10,7 +10,7 @@ defmodule Mail.Encoder do
   def encode(data, encoding) do
     case encoding do
       :base64 -> Mail.Encoders.Base64.encode(data)
-      _ -> Mail.Encoders.Identity.encode(data)
+      _ -> Mail.Encoders.Binary.encode(data)
     end
   end
 
@@ -19,7 +19,7 @@ defmodule Mail.Encoder do
   def decode(data, encoding) do
     case encoding do
       :base64 -> Mail.Encoders.Base64.decode(data)
-      _ -> Mail.Encoders.Identity.decode(data)
+      _ -> Mail.Encoders.Binary.decode(data)
     end
   end
 end

--- a/lib/mail/encoders/binary.ex
+++ b/lib/mail/encoders/binary.ex
@@ -1,0 +1,18 @@
+defmodule Mail.Encoders.Binary do
+  @moduledoc """
+  Encodes/decodes binary strings according to RFC 2045.
+
+  See the following link for reference:
+  - <https://tools.ietf.org/html/rfc2045#section-2.9>
+  """
+
+  @doc """
+  Encodes a string into a binary encoded string.
+  """
+  def encode(string), do: string
+
+  @doc """
+  Decodes a binary encoded string.
+  """
+  def decode(string), do: string
+end

--- a/lib/mail/encoders/identity.ex
+++ b/lib/mail/encoders/identity.ex
@@ -1,6 +1,0 @@
-defmodule Mail.Encoders.Identity do
-  def encode(string),
-    do: string
-  def decode(string),
-    do: string
-end

--- a/test/mail/encoders/binary_test.exs
+++ b/test/mail/encoders/binary_test.exs
@@ -1,0 +1,21 @@
+defmodule Mail.Encoders.BinaryTest do
+  use ExUnit.Case
+
+  test "encode handles empty strings" do
+    assert Mail.Encoders.Binary.encode("") == ""
+  end
+
+  test "encodes all data as-is" do
+    message = "hełło\0world\r\n"
+    assert Mail.Encoders.Binary.encode(message) == message
+  end
+
+  test "decode handles empty strings" do
+    assert Mail.Encoders.Binary.decode("") == ""
+  end
+
+  test "decode all data as-is" do
+    message = "hełło\0world\r\n"
+    assert Mail.Encoders.Binary.decode(message) == message
+  end
+end


### PR DESCRIPTION
Here's the trivial binary encoder implementation. The commit deletes the `Identity` encoder and replaces its usage with the `Binary` encoder.