### PR TITLE
Fix - Guard Added when adding attachment from memory

### DIFF
--- a/lib/mail.ex
+++ b/lib/mail.ex
@@ -119,6 +119,9 @@ defmodule Mail do
   def put_attachment(%Mail.Message{multipart: true} = message, path) when is_binary(path),
     do: Mail.Message.put_part(message, Mail.Message.build_attachment(path))
 
+  def put_attachment(%Mail.Message{multipart: true} = message, path) when is_tuple(path),
+    do: Mail.Message.put_part(message, Mail.Message.build_attachment(path))
+
   def put_attachment(%Mail.Message{} = message, path) when is_binary(path),
     do: Mail.Message.put_attachment(message, path)
 


### PR DESCRIPTION
<!--
Thank you for contributing!

Here are a few things that will increase the chance that your pull request will get accepted:
 - Write tests, preferably in a test driven style.
 - Add documentation for the changes you made.
 - Follow our styleguide: https://github.com/dockyard/styleguides
-->

<!-- If this pull request addresses an issue please provide the issue number here -->

Closes 40 .

https://github.com/DockYard/elixir-mail/issues/40
## Changes proposed in this pull request

<!-- Please describe here what this pull request changes -->

Guard added for adding attachment from memory

```
def put_attachment(%Mail.Message{multipart: true} = message, path) when is_tuple(path),
    do: Mail.Message.put_part(message, Mail.Message.build_attachment(path))
```
