### PR TITLE
Parse boundary without quotes

### DIFF
--- a/lib/mail/parsers/rfc_2822.ex
+++ b/lib/mail/parsers/rfc_2822.ex
@@ -2,7 +2,7 @@ defmodule Mail.Parsers.RFC2822 do
   @moduledoc """
   RFC2822 Parser
 
-  Will attempt to parse a valid RFC2822 message back into 
+  Will attempt to parse a valid RFC2822 message back into
   a `%Mail.Message{}` data model.
 
       Mail.Parsers.RFC2822.parse(message)
@@ -130,8 +130,6 @@ defmodule Mail.Parsers.RFC2822 do
   end
 
   defp get_boundary(nil), do: nil
-  defp get_boundary(boundary) do
-    Regex.run(~r/"(.+)"/, boundary)
-    |> List.last()
-  end
+  defp get_boundary("\"" <> boundary), do: String.slice(boundary, 0..-2)
+  defp get_boundary(boundary), do: boundary
 end

--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -29,7 +29,7 @@ defmodule Mail.Parsers.RFC2822Test do
     From: Me <me@example.com>
     Subject: Test email
     Mime-Version: 1.0
-    Content-Type: multipart/alternative; boundary="foobar"
+    Content-Type: multipart/alternative; boundary=foobar
 
     --foobar
     Content-Type: text/plain


### PR DESCRIPTION
If a boundary is non-quoted `Content-Type: multipart/alternative; boundary=foobar` instead of `Content-Type: multipart/alternative; boundary="foobar"` the parser failes.
I changed one of the tests to use an unquoted boundary instead of creating a new test.