### PR TITLE
Fix parse of long header \w wrapped body

### DIFF
--- a/lib/mail/parsers/rfc_2822.ex
+++ b/lib/mail/parsers/rfc_2822.ex
@@ -45,7 +45,7 @@ defmodule Mail.Parsers.RFC2822 do
 
   defp parse_headers(message, headers) do
     headers = String.split(headers, ~r/\r\n(?!\s+)/s)
-      |> Enum.map(&(String.split(&1, ": ", parts: 2)))
+      |> Enum.map(&(String.split(&1, ":", parts: 2)))
       |> Enum.into(%{}, fn([key, value]) ->
         {key_to_atom(key), parse_header_value(key, value)}
       end)
@@ -53,6 +53,15 @@ defmodule Mail.Parsers.RFC2822 do
     Map.put(message, :headers, headers)
     |> Map.put(:multipart, multipart?(headers))
   end
+
+  defp parse_header_value(key, " " <> value),
+    do: parse_header_value(key, value)
+  defp parse_header_value(key, "\r" <> value),
+    do: parse_header_value(key, value)
+  defp parse_header_value(key, "\n" <> value),
+    do: parse_header_value(key, value)
+  defp parse_header_value(key, "\t" <> value),
+    do: parse_header_value(key, value)
 
   defp parse_header_value("To", value),
     do: parse_recipient_value(value)

--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -195,4 +195,18 @@ defmodule Mail.Parsers.RFC2822Test do
 
     assert message.headers[:content_type] == ["multipart/mixed", boundary: "----=_Part_295474_20544590.1456382229928"]
   end
+
+  test "parse long, wrapped header" do
+    mail = """
+    X-ReallyLongHeaderNameThatCausesBodyToWrap:
+    \tBodyOnNewLine
+
+    Body
+    """
+    |> String.replace("\n", "\r\n")
+
+    message = Mail.Parsers.RFC2822.parse(mail)
+
+    assert message.headers[:x_reallylongheadernamethatcausesbodytowrap] == "BodyOnNewLine"
+  end
 end


### PR DESCRIPTION
This fixes a bug where the entire body of a wrapped header is on a new line.