### PR TITLE
Fix bug parsing empty mail body

### DIFF
--- a/lib/mail/parsers/rfc_2822.ex
+++ b/lib/mail/parsers/rfc_2822.ex
@@ -12,7 +12,7 @@ defmodule Mail.Parsers.RFC2822 do
   @months ~w(Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec)
 
   def parse(content) do
-    matcher = ~r/^(\r\n)?(?<headers>.+?)\r\n\r\n(?<body>.+)/s
+    matcher = ~r/^(\r\n)?(?<headers>.+?)\r\n\r\n(?<body>.*)/s
     %{"headers" => headers, "body" => body} = Regex.named_captures(matcher, content)
 
     %Mail.Message{}

--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -192,6 +192,18 @@ defmodule Mail.Parsers.RFC2822Test do
     assert message.headers[:x_reallylongheadernamethatcausesbodytowrap] == "BodyOnNewLine"
   end
 
+  test "allow empty body (RFC2822 §3.5)" do
+    message = parse_email("""
+    To: Test User <user@example.com>
+    From: Me <me@example.com>
+    Date: Fri, 1 Jan 2016 00:00:00 +0000
+    Subject: Blank body
+
+    """)
+
+    assert message.body == ""
+  end
+
   defp parse_email(email),
     do: email |> convert_crlf |> Mail.Parsers.RFC2822.parse
 


### PR DESCRIPTION
RFC2822 §2.1, “A message consists of header fields (collectively called "the header of the message") followed, optionally, by a body.”

Note, this patch follows #48 