### PR TITLE
Expose put attachment data

### DIFF
--- a/lib/mail.ex
+++ b/lib/mail.ex
@@ -113,14 +113,21 @@ defmodule Mail do
   Add an attachment part to the message
 
       Mail.put_attachment(%Mail.Message{}, "README.md")
-
+      Mail.put_attachment(%Mail.Message{}, {"README.md", data})
+      
   Each call will add a new attachment part.
   """
   def put_attachment(%Mail.Message{multipart: true} = message, path) when is_binary(path),
     do: Mail.Message.put_part(message, Mail.Message.build_attachment(path))
 
+  def put_attachment(%Mail.Message{multipart: true} = message, {filename, data}),
+    do: Mail.Message.put_part(message, Mail.Message.build_attachment({filename, data}))
+
   def put_attachment(%Mail.Message{} = message, path) when is_binary(path),
     do: Mail.Message.put_attachment(message, path)
+
+  def put_attachment(%Mail.Message{} = message, {filename, data}),
+    do: Mail.Message.put_attachment(message, {filename, data})
 
   @doc """
   Add a new `subject` header

--- a/test/mail_test.exs
+++ b/test/mail_test.exs
@@ -244,7 +244,7 @@ defmodule MailTest do
     assert is_nil(Mail.get_html(mail))
   end
 
-  test "put_attachment with a simglepart" do
+  test "put_attachment with a singlepart" do
     mail = Mail.put_attachment(Mail.build(), "README.md")
 
     assert Enum.empty?(mail.parts)
@@ -254,6 +254,19 @@ defmodule MailTest do
     assert Mail.Message.get_content_type(mail) == ["text/markdown"]
     assert Mail.Message.get_header(mail, :content_disposition) == [:attachment, filename: "README.md"]
     assert Mail.Message.get_header(mail, :content_transfer_encoding) == :base64
+    assert mail.body == file_content
+  end
+
+  test "put_attachment (from memory) with a singlepart" do
+    {:ok, file_content} = File.read("README.md")
+
+    mail = Mail.put_attachment(Mail.build(), {"DOESNOTEXIST.md", file_content})
+
+    assert Enum.empty?(mail.parts)
+
+    assert Mail.Message.get_content_type(mail) == ["text/markdown"]
+    assert mail.headers.content_disposition == [:attachment, filename: "DOESNOTEXIST.md"]
+    assert mail.headers.content_transfer_encoding == :base64
     assert mail.body == file_content
   end
 
@@ -268,6 +281,20 @@ defmodule MailTest do
     assert Mail.Message.get_content_type(part) == ["text/markdown"]
     assert Mail.Message.get_header(part, :content_disposition) == [:attachment, filename: "README.md"]
     assert Mail.Message.get_header(part, :content_transfer_encoding) == :base64
+    assert part.body == file_content
+  end
+
+  test "put_attachment (from memory) with a multipart" do
+    {:ok, file_content} = File.read("README.md")
+
+    mail = Mail.put_attachment(Mail.build_multipart(), {"DOESNOTEXIST.md", file_content})
+
+    assert length(mail.parts) == 1
+    part = List.first(mail.parts)
+
+    assert Mail.Message.get_content_type(part) == ["text/markdown"]
+    assert part.headers.content_disposition == [:attachment, filename: "DOESNOTEXIST.md"]
+    assert part.headers.content_transfer_encoding == :base64
     assert part.body == file_content
   end
 


### PR DESCRIPTION
The ability to add attachments from in-memory data instead of an on-disk file was not exposed in the Mail module. I think this was an oversight?
