### PR TITLE
Modified Base64 encoding to use iolist for intermediate string concatenation

### DIFF
--- a/lib/mail/encoders/base64.ex
+++ b/lib/mail/encoders/base64.ex
@@ -14,11 +14,14 @@ defmodule Mail.Encoders.Base64 do
     do: string
         |> Base.encode64()
         |> add_line_breaks()
+        |> List.flatten()
+        |> Enum.join()
 
   def decode(string),
     do: :base64.mime_decode(string)
 
   defp add_line_breaks(<< head :: binary-size(76), tail :: binary >>),
-    do: head <> "\r\n" <> add_line_breaks(tail)
-  defp add_line_breaks(tail), do: tail <> "\r\n"
+    do: [head, "\r\n" | add_line_breaks(tail)]
+
+  defp add_line_breaks(tail), do: [tail, "\r\n"]
 end


### PR DESCRIPTION
We ran into a massive memory problem with the base64 encoder.

Using a 1mb+ binary payload the encoder would crap itself sometimes and end with the system using all it's available resources, killing the erlang/elixir vm.

I've modified the encoder slightly to use iolists for the byte splits, finally joining them all at the very end.

This reduces the String allocations during the process