### PR TITLE
fix attachment header

### DIFF
--- a/lib/mail/message.ex
+++ b/lib/mail/message.ex
@@ -204,10 +204,10 @@ defmodule Mail.Message do
   The mimetype of the file is determined by the file extension.
 
       Mail.Message.build_attachment("README.md")
-      %Mail.Message{data: "base64 encoded", headers: %{content_type: ["text/x-markdown"], content_disposition: [:attachment, filename: "README.md"], content_transfer_encoding: :base64}}
+      %Mail.Message{data: "base64 encoded", headers: %{content_type: ["text/x-markdown"], content_disposition: ["attachment", filename: "README.md"], content_transfer_encoding: :base64}}
 
       Mail.Message.build_attachment({"README.md", "file contents})
-      %Mail.Message{data: "base64 encoded", headers: %{content_type: ["text/x-markdown"], content_disposition: [:attachment, filename: "README.md"], content_transfer_encoding: :base64}}
+      %Mail.Message{data: "base64 encoded", headers: %{content_type: ["text/x-markdown"], content_disposition: ["attachment", filename: "README.md"], content_transfer_encoding: :base64}}
 
   ## Options
 
@@ -241,10 +241,10 @@ defmodule Mail.Message do
   The first argument must be a `Mail.Message`. The remaining argument is descibed in `build_attachment/1`
 
       Mail.Message.put_attachment(%Mail.Message{}, "README.md")
-      %Mail.Message{data: "base64 encoded", headers: %{content_type: ["text/x-markdown"], content_disposition: [:attachment, filename: "README.md"], content_transfer_encoding: :base64}}
+      %Mail.Message{data: "base64 encoded", headers: %{content_type: ["text/x-markdown"], content_disposition: ["attachment", filename: "README.md"], content_transfer_encoding: :base64}}
 
       Mail.Message.put_attachment(%Mail.Message{}, {"README.md", "file contents})
-      %Mail.Message{data: "base64 encoded", headers: %{content_type: ["text/x-markdown"], content_disposition: [:attachment, filename: "README.md"], content_transfer_encoding: :base64}}
+      %Mail.Message{data: "base64 encoded", headers: %{content_type: ["text/x-markdown"], content_disposition: ["attachment", filename: "README.md"], content_transfer_encoding: :base64}}
   """
   def put_attachment(message, path_or_file_tuple)
   def put_attachment(%Mail.Message{} = message, path) when is_binary(path) do
@@ -258,7 +258,7 @@ defmodule Mail.Message do
 
     put_body(message, data)
     |> put_content_type(mimetype(filename))
-    |> put_header(:content_disposition, [:attachment, filename: filename])
+    |> put_header(:content_disposition, ["attachment", filename: filename])
     |> put_header(:content_transfer_encoding, :base64)
   end
 
@@ -268,7 +268,7 @@ defmodule Mail.Message do
   Returns `Boolean`
   """
   def is_attachment?(message),
-    do: Enum.member?(List.wrap(get_header(message, :content_disposition)), :attachment)
+    do: Enum.member?(List.wrap(get_header(message, :content_disposition)), "attachment")
 
   @doc """
   Determines the message has any attachment parts

--- a/test/mail/message_test.exs
+++ b/test/mail/message_test.exs
@@ -106,7 +106,7 @@ defmodule Mail.MessageTest do
     {:ok, file_content} = File.read("README.md")
 
     assert Mail.Message.get_content_type(part) == ["text/markdown"]
-    assert Mail.Message.get_header(part, :content_disposition) == [:attachment, filename: "README.md"]
+    assert Mail.Message.get_header(part, :content_disposition) == ["attachment", filename: "README.md"]
     assert Mail.Message.get_header(part, :content_transfer_encoding) == :base64
     assert part.body == file_content
   end
@@ -116,7 +116,7 @@ defmodule Mail.MessageTest do
     {:ok, file_content} = File.read("README.md")
 
     assert Mail.Message.get_content_type(part) == ["text/markdown"]
-    assert Mail.Message.get_header(part, :content_disposition) == [:attachment, filename: "README.md"]
+    assert Mail.Message.get_header(part, :content_disposition) == ["attachment", filename: "README.md"]
     assert Mail.Message.get_header(part, :content_transfer_encoding) == :base64
     assert part.body == file_content
   end

--- a/test/mail_test.exs
+++ b/test/mail_test.exs
@@ -252,7 +252,7 @@ defmodule MailTest do
     {:ok, file_content} = File.read("README.md")
 
     assert Mail.Message.get_content_type(mail) == ["text/markdown"]
-    assert Mail.Message.get_header(mail, :content_disposition) == [:attachment, filename: "README.md"]
+    assert Mail.Message.get_header(mail, :content_disposition) == ["attachment", filename: "README.md"]
     assert Mail.Message.get_header(mail, :content_transfer_encoding) == :base64
     assert mail.body == file_content
   end
@@ -266,7 +266,7 @@ defmodule MailTest do
     {:ok, file_content} = File.read("README.md")
 
     assert Mail.Message.get_content_type(part) == ["text/markdown"]
-    assert Mail.Message.get_header(part, :content_disposition) == [:attachment, filename: "README.md"]
+    assert Mail.Message.get_header(part, :content_disposition) == ["attachment", filename: "README.md"]
     assert Mail.Message.get_header(part, :content_transfer_encoding) == :base64
     assert part.body == file_content
   end


### PR DESCRIPTION
When parsing real emails, `Content-Disposition` consists of two parts and the first part should be parsed to a string. 
example:
```
Content-Disposition: attachment;\r\n filename=\"=?utf-8?B?QWdlbmN5IFN0YXRlbWVudCBSZXBvcnQueGxzeA==?=\"
```
parsed in:
```elixir
%{"content-disposition" => ["attachment",
    {:filename, "\"=?utf-8?B?QWdlbmN5IFN0YXRlbWVudCBSZXBvcnQueGxzeA==?=\""}]
```
But in `Mail.Message.is_attachment?/1` function and other places used `:attachment` atom.

This PR fixed this.