### PR TITLE
add Mail.has_attachments/1

### DIFF
--- a/lib/mail.ex
+++ b/lib/mail.ex
@@ -312,6 +312,25 @@ defmodule Mail do
     renderer.render(message)
   end
 
+  @doc """
+  Determines the mail has any attachment parts
+
+  Argument must be a `Mail.Message` or `List` of `Mail.Message`
+
+  Returns a `Boolean`
+  """
+  def has_attachments?(%Mail.Message{} = message) do
+    has_attachments?([message])
+  end
+  def has_attachments?(parts) when is_list(parts) do
+    Enum.any?(parts, &has_attachment?/1)
+  end
+
+  defp has_attachment?(%Mail.Message{multipart: true} = message) do
+    if Mail.Message.is_attachment?(message), do: true, else: has_attachments?(message.parts)
+  end
+  defp has_attachment?(%Mail.Message{multipart: false} = message), do: Mail.Message.is_attachment?(message)
+
   defp validate_recipients([]), do: nil
   defp validate_recipients([recipient|tail]) do
     case recipient do

--- a/test/mail_test.exs
+++ b/test/mail_test.exs
@@ -279,4 +279,23 @@ defmodule MailTest do
 
     assert result == "Test!"
   end
+
+  test "has_attachments" do
+    message_with_attachment =
+      %Mail.Message{body: "new part"}
+      |> Mail.Message.put_attachment("CHANGELOG.md")
+    message =
+      %Mail.Message{multipart: true}
+      |> Mail.Message.put_part(message_with_attachment)
+
+    assert Mail.has_attachments?(message) == true
+  end
+
+  test "has_attachments without attachments" do
+    message =
+      %Mail.Message{multipart: true}
+      |> Mail.Message.put_part(%Mail.Message{body: "second new part"})
+
+    assert Mail.has_attachments?(message) == false
+  end
 end


### PR DESCRIPTION
I usually have to parse emails with the following structure:
```
%Mail.Message{
  body: nil,
  headers: %{"many headers with information about mail"},
  multipart: true,
  parts: [
    %Mail.Message{
      body: nil,
      headers: %{"content-type" => ["multipart/alternative",
      {:boundary, "--boundary_229w_353535-29d4-sd35-b6fd-884e2356d9f4"}]},
      multipart: true,
      parts: [
        %Mail.Message{
          body: "Mail in text format",
          headers: %{"content-transfer-encoding" => "7bit",
                     "content-type" => ["text/plain", {:charset, "utf-8"}]}, 
          multipart: false,
          parts: []
        },
        %Mail.Message{
          body: "Mail in html format",
          headers: %{"content-transfer-encoding" => "quoted-printable",
                     "content-type" => ["text/html", {:charset, "utf-8"}]}, 
          multipart: false,
          parts: []
        }
      ]
    },
    %Mail.Message{
      body: nil,
      headers: %{"content-type" => ["multipart/mixed", {:boundary, "--boundary_2297_104bbbda-d049-5673-ab25-29b34676ad90"}]},
      multipart: true,
      parts: [
        %Mail.Message{
          body: <<80, 75, 3, 4, 20, 0, 0, 0, 8, 0, 106, 52, 67, 108, 47, 119, 111, 114, 107, 98, ...>>,
          headers: %{
            "content-disposition" => [
              "attachment",
              {:filename,"\"=?utf-8?B?sdsd5IFsfN0YXRlbsdcnQueGxzeA==?=\""}
            ],
            "content-id" => "<bce21830-03434-4742-99b2-9700e5add4ac>",
            "content-transfer-encoding" => "base64",
            "content-type" => [
              "application/octet-stream",
              {:name, "\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet\""}
            ]
          },
          multipart: false, 
          parts: []
        }
      ]
    }
  ]
}
```
Attachments located on the 3rd level of nesting, so function `Mail.Message.has_attachment?/1` is not relevant. 
I added a function `has_attachments?` in Mail module, which recursively iterates through all the messages and check `Mail.Message.is_attachment?`.
