### PR TITLE
fix test for elixir 1.4.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: elixir
 elixir:
   - 1.3.0
+  - 1.4.2
 otp_release:
   - 18.0
 sudo: false # to use faster container based build environment

--- a/lib/mail/test_assertions.ex
+++ b/lib/mail/test_assertions.ex
@@ -55,11 +55,12 @@ defmodule Mail.TestAssertions do
       headers["content-type"]
       |> List.wrap()
 
-    case Keyword.fetch(content_type, :boundary) do
-      nil -> headers
-      _boundary ->
-        content_type = put_in(content_type, [:boundary], "")
-        put_in(headers, ["content-type"], content_type)
-    end
+    content_type = Enum.map(content_type, fn(item) ->
+      case item do
+        {:boundary, _} -> {:boundary, ""}
+        _ -> item
+      end
+    end)
+    put_in(headers, ["content-type"], content_type)
   end
 end


### PR DESCRIPTION
In Elixir 1.4.x `put_in` on list with `String` items rise FunctionClauseError exeption
```
iex (1)> put_in(["multipart/alternative", {:boundary, "foobar"}], [:boundary], "")
** (FunctionClauseError) no function clause matching in Keyword.get_and_update/4
    (elixir) lib/keyword.ex:227: Keyword.get_and_update(["multipart/alternative", {:boundary, "foobar"}], [], :boundary, #Function<12.40206377/1 in Kernel.put_in/3>)
    (elixir) lib/kernel.ex:1831: Kernel.put_in/3
```