### PR TITLE
Change to the Encoder module

### DIFF
--- a/lib/mail/encoder.ex
+++ b/lib/mail/encoder.ex
@@ -8,8 +8,8 @@ defmodule Mail.Encoder do
   @spec encoder_for(encoding :: String.t | atom) :: atom
   def encoder_for(encoding) when is_atom(encoding) do
     encoding
-    |> Atom.to_string
-    |> encoder_for
+    |> Atom.to_string()
+    |> encoder_for()
   end
 
   def encoder_for(encoding) when is_binary(encoding) do

--- a/lib/mail/encoder.ex
+++ b/lib/mail/encoder.ex
@@ -5,21 +5,26 @@ defmodule Mail.Encoder do
   Will delegate to the proper encoding/decoding functions based upon name
   """
 
-  def encode(data, encoding) when is_binary(encoding),
-    do: encode(data, String.to_atom(encoding))
-  def encode(data, encoding) do
-    case encoding do
-      :base64 -> Mail.Encoders.Base64.encode(data)
-      _ -> Mail.Encoders.Binary.encode(data)
+  @spec encoder_for(encoding :: String.t | atom) :: atom
+  def encoder_for(encoding) when is_atom(encoding) do
+    encoding
+    |> Atom.to_string
+    |> encoder_for
+  end
+
+  def encoder_for(encoding) when is_binary(encoding) do
+    case String.downcase(encoding) do
+      "7bit" -> Mail.Encoders.SevenBit
+      "8bit" -> Mail.Encoders.EightBit
+      "base64" -> Mail.Encoders.Base64
+      "quoted-printable" -> Mail.Encoders.QuotedPrintable
+      _ -> Mail.Encoders.Binary
     end
   end
 
-  def decode(data, encoding) when is_binary(encoding),
-    do: decode(data, String.to_atom(encoding))
-  def decode(data, encoding) do
-    case encoding do
-      :base64 -> Mail.Encoders.Base64.decode(data)
-      _ -> Mail.Encoders.Binary.decode(data)
-    end
-  end
+  @spec encode(data :: binary, encoding :: String.t) :: binary
+  def encode(data, encoding), do: encoder_for(encoding).encode(data)
+
+  @spec decode(data :: binary, encoding :: String.t) :: binary
+  def decode(data, encoding), do: encoder_for(encoding).decode(data)
 end

--- a/lib/mail/encoder.ex
+++ b/lib/mail/encoder.ex
@@ -13,7 +13,7 @@ defmodule Mail.Encoder do
   end
 
   def encoder_for(encoding) when is_binary(encoding) do
-    case String.downcase(encoding) do
+    case encoding |> String.trim |> String.downcase do
       "7bit" -> Mail.Encoders.SevenBit
       "8bit" -> Mail.Encoders.EightBit
       "base64" -> Mail.Encoders.Base64

--- a/test/mail/encoder_test.exs
+++ b/test/mail/encoder_test.exs
@@ -1,0 +1,38 @@
+defmodule Mail.EncoderTest do
+  use ExUnit.Case, async: true
+  alias Mail.Encoder
+
+  describe "encode/decode" do
+    test "encodes a binary in 7bit" do
+      # odd casing
+      # nothing to do here really...
+      assert "Hello,\nWorld" == Encoder.encode("Hello,\nWorld", "7BIT")
+      assert "Hello,\nWorld" == Encoder.decode("Hello,\nWorld", "7Bit")
+    end
+
+    test "encodes a binary in 8bit" do
+      # odd casing
+      # nothing to do here really...
+      assert "Hello,\nWorld" == Encoder.encode("Hello,\nWorld", "8BIT")
+      assert "Hello,\nWorld" == Encoder.decode("Hello,\nWorld", "8Bit")
+    end
+
+    test "encodes a binary as base64" do
+      # with odd casings
+      assert "SGVsbG8sIFdvcmxk\r\n" == Encoder.encode("Hello, World", "BASE64")
+      assert "Hello, World" == Encoder.decode("SGVsbG8sIFdvcmxk\r\n", "Base64")
+    end
+
+    test "encodes a binary in quoted-printable" do
+      # odd casing
+      assert "Hello,=0AWorld" == Encoder.encode("Hello,\nWorld", "Quoted-Printable")
+      assert "Hello,\nWorld" == Encoder.decode("Hello,=0AWorld", "QUOTED-PRINTABLE")
+    end
+
+    test "... everything else" do
+      assert "Hello,\nWorld" == Encoder.encode("Hello,\nWorld", "ASCII")
+      assert "Hello,\nWorld" == Encoder.decode("Hello,\nWorld", "UTF-8")
+      assert "Hello,\nWorld" == Encoder.decode("Hello,\nWorld", "binary")
+    end
+  end
+end


### PR DESCRIPTION
I've had some oddities regarding the Encoder module for some time, 
where a content-transfer-encoding with BASE64 doesn't get converted, or where quoted-printable content didn't get encoded, resulting in nasty bare newline errors from our smtp server.

And to my surprise a String.to_atom in the code (I don't want to have every varition of Base64|BASE64|BasE64|base64 sitting in the vm memory permanently)

* Do not convert incoming encoding strings to atoms, atoms aren't GC-ed. (a memory leak if you
get different encodings each time in different casings)
* Normalize the encoding (some servers, clients will send BASE64 or
Base64 instead of base64)
* Support 7bit, 8bit, and quoted-printable (especially quoted-printable)
