### PR TITLE
Strings for content subtypes and proplist

### DIFF
--- a/lib/mail/parsers/rfc_2822.ex
+++ b/lib/mail/parsers/rfc_2822.ex
@@ -127,7 +127,7 @@ defmodule Mail.Parsers.RFC2822 do
     do: value
 
   defp parse_structured_header_value(value) do
-    case String.split(value, ~r/;\s+/) do
+    case String.split(value, ~r/;\s*/) do
       [value | []] -> value
       [value | subtypes] -> [value | parse_header_subtypes(subtypes)]
     end
@@ -142,7 +142,7 @@ defmodule Mail.Parsers.RFC2822 do
   end
 
   defp parse_received_value(value) do
-    [value | [date]] = String.split(value, ~r/;\s+/)
+    [value | [date]] = String.split(value, ~r/;\s*/)
     [value | [{"date", erl_from_timestamp(date)}]]
   end
 

--- a/lib/mail/proplist.ex
+++ b/lib/mail/proplist.ex
@@ -28,6 +28,21 @@ defmodule Mail.Proplist do
   end
 
   @doc """
+  Detects if the list contains the specified key.
+
+  Args:
+  * `list` - the list to look in
+  * `key` - the key to look for
+  """
+  @spec has_key?(list :: __MODULE__.t, key :: term) :: [term]
+  def has_key?(list, key) do
+    Enum.any?(list, fn
+      {k, _value} -> key == k
+      _value -> false
+    end)
+  end
+
+  @doc """
   Stores a key-value pair in the list, will replace an existing pair with the
   same key.
 
@@ -67,10 +82,7 @@ defmodule Mail.Proplist do
   def merge(a, b) do
     Enum.reduce(a ++ b, [], fn
       {key, _value} = value, acc ->
-        if Enum.any?(acc, fn
-            {subkey, _value} -> key == subkey
-            value -> false
-          end) do
+        if has_key?(acc, key) do
           :lists.keystore(key, 1, acc, value)
         else
           [value | acc]

--- a/lib/mail/proplist.ex
+++ b/lib/mail/proplist.ex
@@ -1,0 +1,72 @@
+defmodule Mail.Proplist do
+  @type t :: [{term, term} | term]
+
+  @spec keys(list :: __MODULE__.t) :: [term]
+  def keys(list) do
+    Enum.reduce(list, [], fn
+      {key, _value}, acc ->
+        if Enum.member?(acc, key) do
+          acc
+        else
+          [key | acc]
+        end
+
+      value, acc -> acc
+    end)
+    |> Enum.reverse()
+  end
+
+  @spec put(list :: __MODULE__.t, key :: term, value :: term) :: __MODULE__.t
+  def put(list, key, value) do
+    :lists.keystore(key, 1, list, {key, value})
+  end
+
+  @spec get(list :: __MODULE__.t, key :: term) :: __MODULE__.t
+  def get(list, key) do
+    case :proplists.get_value(key, list) do
+      :undefined -> nil
+      value -> value
+    end
+  end
+
+  @spec merge(a :: __MODULE__.t, b :: __MODULE__.t) :: __MODULE__.t
+  def merge(a, b) do
+    Enum.reduce(a ++ b, [], fn
+      {key, _value} = value, acc ->
+        if Enum.any?(acc, fn
+            {subkey, _value} -> key == subkey
+            value -> false
+          end) do
+          :lists.keystore(key, 1, acc, value)
+        else
+          [value | acc]
+        end
+      value, acc ->
+        [value | acc]
+    end)
+    |> Enum.reverse()
+  end
+
+  @spec delete(list :: __MODULE__.t, key :: term) :: __MODULE__.t
+  def delete(list, key) do
+    :proplists.delete(key, list)
+  end
+
+  @spec filter(list :: __MODULE__.t, func :: any) :: __MODULE__.t
+  def filter(list, func) do
+    Enum.filter(list, fn
+      {key, _value} = value -> func.(value)
+      value -> true
+    end)
+  end
+
+  @spec drop(list :: __MODULE__.t, keys :: list) :: __MODULE__.t
+  def drop(list, keys) do
+    filter(list, fn {key, value} -> !Enum.member?(keys, key) end)
+  end
+
+  @spec take(list :: __MODULE__.t, keys :: list) :: __MODULE__.t
+  def take(list, keys) do
+    filter(list, fn {key, value} -> Enum.member?(keys, key) end)
+  end
+end

--- a/lib/mail/proplist.ex
+++ b/lib/mail/proplist.ex
@@ -1,6 +1,17 @@
 defmodule Mail.Proplist do
+  @moduledoc """
+  A hybrid of erlang's proplists and lists keystores
+  """
+
   @type t :: [{term, term} | term]
 
+  @doc """
+  Retrieves all keys from the key value pairs present in the list,
+  unlike :proplists.get_keys which will return non-kv pairs as keys
+
+  Args:
+  * `list` - a list to retrieve all the keys from
+  """
   @spec keys(list :: __MODULE__.t) :: [term]
   def keys(list) do
     Enum.reduce(list, [], fn
@@ -16,11 +27,27 @@ defmodule Mail.Proplist do
     |> Enum.reverse()
   end
 
+  @doc """
+  Stores a key-value pair in the list, will replace an existing pair with the
+  same key.
+
+  Args:
+  * `list` - the list to store in
+  * `key` - the key of the pair
+  * `value` - the value of the pair
+  """
   @spec put(list :: __MODULE__.t, key :: term, value :: term) :: __MODULE__.t
   def put(list, key, value) do
     :lists.keystore(key, 1, list, {key, value})
   end
 
+  @doc """
+  Retrieves a value from the list
+
+  Args:
+  * `list` - the list to look in
+  * `key` - the key of the pair to retrieve it's value
+  """
   @spec get(list :: __MODULE__.t, key :: term) :: __MODULE__.t
   def get(list, key) do
     case :proplists.get_value(key, list) do
@@ -29,6 +56,13 @@ defmodule Mail.Proplist do
     end
   end
 
+  @doc """
+  Concatentates the given lists.
+
+  Args:
+  * `a` - base list to merge unto
+  * `b` - list to merge with
+  """
   @spec merge(a :: __MODULE__.t, b :: __MODULE__.t) :: __MODULE__.t
   def merge(a, b) do
     Enum.reduce(a ++ b, [], fn
@@ -47,11 +81,26 @@ defmodule Mail.Proplist do
     |> Enum.reverse()
   end
 
+  @doc """
+  Removes a key-value pair by the given key and returns the remaining list
+
+  Args:
+  * `list` - the list to remove the pair from
+  * `key` - the key to remove
+  """
   @spec delete(list :: __MODULE__.t, key :: term) :: __MODULE__.t
   def delete(list, key) do
     :proplists.delete(key, list)
   end
 
+  @doc """
+  Filters the proplist, i.e. returns only those elements
+  for which `fun` returns a truthy value.
+
+  Args:
+  * `list` - the list to filter
+  * `func` - the function to execute
+  """
   @spec filter(list :: __MODULE__.t, func :: any) :: __MODULE__.t
   def filter(list, func) do
     Enum.filter(list, fn
@@ -60,11 +109,25 @@ defmodule Mail.Proplist do
     end)
   end
 
+  @doc """
+  Drops the specified keys from the list, returning the remaining.
+
+  Args:
+  * `list` - the list
+  * `keys` - the keys to remove
+  """
   @spec drop(list :: __MODULE__.t, keys :: list) :: __MODULE__.t
   def drop(list, keys) do
     filter(list, fn {key, value} -> !Enum.member?(keys, key) end)
   end
 
+  @doc """
+  Takes the specified keys from the list, returning the remaining.
+
+  Args:
+  * `list` - the list
+  * `keys` - the keys to keep
+  """
   @spec take(list :: __MODULE__.t, keys :: list) :: __MODULE__.t
   def take(list, keys) do
     filter(list, fn {key, value} -> Enum.member?(keys, key) end)

--- a/lib/mail/test_assertions.ex
+++ b/lib/mail/test_assertions.ex
@@ -55,10 +55,10 @@ defmodule Mail.TestAssertions do
       headers["content-type"]
       |> List.wrap()
 
-    case Keyword.fetch(content_type, :boundary) do
+    case Mail.Proplist.get(content_type, "boundary") do
       nil -> headers
       _boundary ->
-        content_type = put_in(content_type, [:boundary], "")
+        content_type = Mail.Proplist.put(content_type, "boundary", "")
         put_in(headers, ["content-type"], content_type)
     end
   end

--- a/test/mail/message_test.exs
+++ b/test/mail/message_test.exs
@@ -62,17 +62,22 @@ defmodule Mail.MessageTest do
 
   test "put_boundary" do
     message = Mail.Message.put_boundary(%Mail.Message{}, "customboundary")
-    assert Mail.Message.get_header(message, :content_type)[:boundary] == "customboundary"
+    boundary =
+      message
+      |> Mail.Message.get_header(:content_type)
+      |> Mail.Proplist.get("boundary")
+
+    assert boundary == "customboundary"
 
     message =
       Mail.Message.put_header(%Mail.Message{}, :content_type, ["multipart/mixed"])
       |> Mail.Message.put_boundary("customboundary")
-    assert Mail.Message.get_header(message, :content_type) == ["multipart/mixed", boundary: "customboundary"]
+    assert Mail.Message.get_header(message, :content_type) == ["multipart/mixed", {"boundary", "customboundary"}]
 
     message =
       Mail.Message.put_header(%Mail.Message{}, :content_type, "multipart/mixed")
       |> Mail.Message.put_boundary("customboundary")
-    assert Mail.Message.get_header(message, :content_type) == ["multipart/mixed", boundary: "customboundary"]
+    assert Mail.Message.get_header(message, :content_type) == ["multipart/mixed", {"boundary", "customboundary"}]
   end
 
   test "get_boundary" do
@@ -106,7 +111,7 @@ defmodule Mail.MessageTest do
     {:ok, file_content} = File.read("README.md")
 
     assert Mail.Message.get_content_type(part) == ["text/markdown"]
-    assert Mail.Message.get_header(part, :content_disposition) == ["attachment", filename: "README.md"]
+    assert Mail.Message.get_header(part, :content_disposition) == ["attachment", {"filename", "README.md"}]
     assert Mail.Message.get_header(part, :content_transfer_encoding) == :base64
     assert part.body == file_content
   end
@@ -116,7 +121,7 @@ defmodule Mail.MessageTest do
     {:ok, file_content} = File.read("README.md")
 
     assert Mail.Message.get_content_type(part) == ["text/markdown"]
-    assert Mail.Message.get_header(part, :content_disposition) == ["attachment", filename: "README.md"]
+    assert Mail.Message.get_header(part, :content_disposition) == ["attachment", {"filename", "README.md"}]
     assert Mail.Message.get_header(part, :content_transfer_encoding) == :base64
     assert part.body == file_content
   end

--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -18,7 +18,7 @@ defmodule Mail.Parsers.RFC2822Test do
     assert message.headers["from"] == "me@example.com"
     assert message.headers["reply-to"] == "otherme@example.com"
     assert message.headers["subject"] == "Test Email"
-    assert message.headers["content-type"] == ["text/plain", foo: "bar", baz: "qux"]
+    assert message.headers["content-type"] == ["text/plain", {"foo", "bar"}, {"baz", "qux"}]
     assert message.body == "This is the body!\r\nIt has more than one line"
   end
 
@@ -48,7 +48,7 @@ defmodule Mail.Parsers.RFC2822Test do
     assert message.headers["cc"] == [{"The Dude", "dude@example.com"}, {"Batman", "batman@example.com"}]
     assert message.headers["from"] == {"Me", "me@example.com"}
     assert message.headers["reply-to"] == {"OtherMe", "otherme@example.com"}
-    assert message.headers["content-type"] == ["multipart/alternative", boundary: "foobar"]
+    assert message.headers["content-type"] == ["multipart/alternative", {"boundary", "foobar"}]
 
     [text_part, html_part] = message.parts
 
@@ -138,12 +138,12 @@ defmodule Mail.Parsers.RFC2822Test do
     assert message.headers["to"] == [{"Test User", "user@example.com"}, {"Other User", "other@example.com"}]
     assert message.headers["cc"] == [{"The Dude", "dude@example.com"}, {"Batman", "batman@example.com"}]
     assert message.headers["from"] == {"Me", "me@example.com"}
-    assert message.headers["content-type"] == ["multipart/mixed", boundary: "foobar"]
+    assert message.headers["content-type"] == ["multipart/mixed", {"boundary", "foobar"}]
     assert message.headers["date"] == {{2016,1,1},{0,0,0}}
 
     [alt_part, attach_part] = message.parts
 
-    assert alt_part.headers["content-type"] == ["multipart/alternative", boundary: "bazqux"]
+    assert alt_part.headers["content-type"] == ["multipart/alternative", {"boundary", "bazqux"}]
     [text_part, html_part] = alt_part.parts
 
     assert text_part.headers["content-type"] == "text/plain"
@@ -153,7 +153,7 @@ defmodule Mail.Parsers.RFC2822Test do
     assert html_part.body == "<h1>This is the HTML</h1>"
 
     assert attach_part.headers["content-type"] == "text/markdown"
-    assert attach_part.headers["content-disposition"] == ["attachment", filename: "README.md"]
+    assert attach_part.headers["content-disposition"] == ["attachment", {"filename", "README.md"}]
     assert attach_part.headers["content-transfer-encoding"] == "base64"
     assert attach_part.body == "Hello world!"
   end
@@ -182,7 +182,7 @@ defmodule Mail.Parsers.RFC2822Test do
     """)
 
     assert message.headers["delivered-to"] == "user@example.com"
-    assert message.headers["received"] == ["by 101.102.103.104 with SMTP id abcdefg", date: {{2016, 4, 1}, {11, 8, 31}}]
+    assert message.headers["received"] == ["by 101.102.103.104 with SMTP id abcdefg", {"date", {{2016, 4, 1}, {11, 8, 31}}}]
     assert message.headers["x-received"] == "201.202.203.204 with SMTP id abcdefg.12.123456;        Fri, 01 Apr 2016 11:08:31 -0700 (PDT)"
     assert message.headers["dkim-signature"] == "v=1; a=rsa-sha256; c=relaxed/relaxed;        d=example.com; s=20160922;        h=mime-version:in-reply-to:references:date:message-id:subject:from:to;        bh=ABCDEFGHABCDEFGHABCDEFGHABCDEFGHABCDEFGHABC=;        b=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890+/         abcd=="
   end
@@ -208,7 +208,7 @@ defmodule Mail.Parsers.RFC2822Test do
     ------=_Part_295474_20544590.1456382229928--
     """)
 
-    assert message.headers["content-type"] == ["multipart/mixed", boundary: "----=_Part_295474_20544590.1456382229928"]
+    assert message.headers["content-type"] == ["multipart/mixed", {"boundary", "----=_Part_295474_20544590.1456382229928"}]
   end
 
   test "parse long, wrapped header" do

--- a/test/mail_test.exs
+++ b/test/mail_test.exs
@@ -252,7 +252,7 @@ defmodule MailTest do
     {:ok, file_content} = File.read("README.md")
 
     assert Mail.Message.get_content_type(mail) == ["text/markdown"]
-    assert Mail.Message.get_header(mail, :content_disposition) == ["attachment", filename: "README.md"]
+    assert Mail.Message.get_header(mail, :content_disposition) == ["attachment", {"filename", "README.md"}]
     assert Mail.Message.get_header(mail, :content_transfer_encoding) == :base64
     assert mail.body == file_content
   end
@@ -266,7 +266,7 @@ defmodule MailTest do
     {:ok, file_content} = File.read("README.md")
 
     assert Mail.Message.get_content_type(part) == ["text/markdown"]
-    assert Mail.Message.get_header(part, :content_disposition) == ["attachment", filename: "README.md"]
+    assert Mail.Message.get_header(part, :content_disposition) == ["attachment", {"filename", "README.md"}]
     assert Mail.Message.get_header(part, :content_transfer_encoding) == :base64
     assert part.body == file_content
   end

--- a/test/proplist_test.exs
+++ b/test/proplist_test.exs
@@ -1,0 +1,61 @@
+defmodule Mail.ProplistTest do
+  use ExUnit.Case, async: true
+  doctest Mail.Proplist
+  alias Mail.Proplist
+
+  describe "keys" do
+    test "retrieves all keys in the specified proplist" do
+      a = [{"a", 2}, {"b", "3"}, {:c, 4}, :d]
+
+      assert ["a", "b", :c] == Proplist.keys(a)
+    end
+  end
+
+  describe "put" do
+    test "puts a key-value pair in the map" do
+      a = [{"a", 2}]
+      assert [{"a", 2}, {"b", 3}] == Proplist.put(a, "b", 3)
+    end
+  end
+
+  describe "get" do
+    test "retrieves a value from the proplist" do
+      a = [{"a", 3}, :a]
+
+      assert 3 == Proplist.get(a, "a")
+    end
+  end
+
+  describe "merge" do
+    test "concatenates two proplists" do
+      a = [{"a", 3}, :a]
+      b = [{"b", 3}, :b]
+
+      assert [{"a", 3}, :a, {"b", 3}, :b] == Proplist.merge(a, b)
+    end
+  end
+
+  describe "delete" do
+    test "concatenates two proplists" do
+      a = [{"a", 3}, {"b", 4}, :a]
+
+      assert [{"a", 3}, :a] == Proplist.delete(a, "b")
+    end
+  end
+
+  describe "drop" do
+    test "removes specified keys from proplist" do
+      a = [{"a", 3}, {"b", 4}, {"c", 5}, :a]
+
+      assert [{"a", 3}, :a] == Proplist.drop(a, ["b", "c"])
+    end
+  end
+
+  describe "take" do
+    test "removes specified keys from proplist" do
+      a = [{"a", 3}, {"b", 4}, {"c", 5}, :a]
+
+      assert [{"b", 4}, {"c", 5}, :a] == Proplist.take(a, ["b", "c"])
+    end
+  end
+end

--- a/test/proplist_test.exs
+++ b/test/proplist_test.exs
@@ -5,41 +5,65 @@ defmodule Mail.ProplistTest do
 
   describe "keys" do
     test "retrieves all keys in the specified proplist" do
-      a = [{"a", 2}, {"b", "3"}, {:c, 4}, :d]
+      assert ["a", "b", :c] == Proplist.keys([{"a", 2}, {"b", "3"}, {:c, 4}, :d])
+      # no items should result in an empty keys list
+      assert [] == Proplist.keys([])
+      # if the list only contains normal values, there should be no keys
+      assert [] == Proplist.keys([:a, :b, :c, "a", "b", "c"])
+    end
+  end
 
-      assert ["a", "b", :c] == Proplist.keys(a)
+  describe "has_key?" do
+    test "determins if the list contains the specified key" do
+      src = [{"a", 2}, {"b", "3"}, :d]
+      assert true == Proplist.has_key?(src, "a")
+      assert true == Proplist.has_key?(src, "b")
+      # an atom as a key will not be treated as a string
+      assert false == Proplist.has_key?(src, :a)
+      assert false == Proplist.has_key?(src, "c")
+      # bare values are not treated as keys
+      assert false == Proplist.has_key?(src, :d)
     end
   end
 
   describe "put" do
     test "puts a key-value pair in the map" do
-      a = [{"a", 2}]
-      assert [{"a", 2}, {"b", 3}] == Proplist.put(a, "b", 3)
+      # inserting a new value
+      assert [{"a", 2}, {"b", 3}] == Proplist.put([{"a", 2}], "b", 3)
+      # replacing an existing value
+      assert [{"a", 2}, {"b", 4}] == Proplist.put([{"a", 2}, {"b", 3}], "b", 4)
     end
   end
 
   describe "get" do
     test "retrieves a value from the proplist" do
-      a = [{"a", 3}, :a]
-
-      assert 3 == Proplist.get(a, "a")
+      # when the key exists
+      assert 3 == Proplist.get([{"a", 3}, :a], "a")
+      # when the key does not exist
+      assert nil == Proplist.get([{"a", 3}, :a], "b")
     end
   end
 
   describe "merge" do
-    test "concatenates two proplists" do
+    test "concatenates two proplists (with new keys)" do
       a = [{"a", 3}, :a]
       b = [{"b", 3}, :b]
 
       assert [{"a", 3}, :a, {"b", 3}, :b] == Proplist.merge(a, b)
     end
+
+    test "concatenates and overwrites keys in the first list" do
+      a = [{"a", 3}, {"b", 3}, :a]
+      b = [{"b", 4}, :b]
+
+      assert [{"a", 3}, {"b", 4}, :a, :b] == Proplist.merge(a, b)
+    end
   end
 
   describe "delete" do
-    test "concatenates two proplists" do
-      a = [{"a", 3}, {"b", 4}, :a]
-
-      assert [{"a", 3}, :a] == Proplist.delete(a, "b")
+    test "removes specified key from the proplist" do
+      assert [{"a", 3}, :a] == Proplist.delete([{"a", 3}, {"b", 4}, :a], "b")
+      assert [{"a", 3}, {"b", 4}, :a] == Proplist.delete([{"a", 3}, {"b", 4}, :a], "c")
     end
   end
 

--- a/test/proplist_test.exs
+++ b/test/proplist_test.exs
@@ -44,6 +44,14 @@ defmodule Mail.ProplistTest do
     end
   end
 
+  describe "normalize" do
+    test "updates duplicate pairs with the latest" do
+      a = [{"a", 3}, {"b", 4}, {"a", 4}, {"b", 5}, {"c", 6}]
+
+      assert [{"a", 4}, {"b", 5}, {"c", 6}] == Proplist.normalize(a)
+    end
+  end
+
   describe "merge" do
     test "concatenates two proplists (with new keys)" do
       a = [{"a", 3}, :a]


### PR DESCRIPTION
## Disclaimer

This is **not** backwards compatible, and will break systems that use Keyword Access on subtype headers.

Merge with caution.

## The PR

To scratch the itch in #16

The changes:

* Fixes Subtype parsing failing when no space is present after the semicolon
```
Content-Type: image/png;Name="myimage.png"
```
There was no space after the semi-colon, resulting in the parser ignoring the type and returning it as is.

* Fixes unchecked String.to_atom on user data, could potentially DOS the system by crafting a mail with enough subtypes to overload the system. (A quick patch would be to use String.to_existing_atom inside a try catch, and returning the string if there is no atom.)
* Always uses strings for the subtypes (Fixes the previous issue)
* Adds a hybrid Proplist module (combines functionality of :proplists and :lists and some hand-rolled code), it's a minimal implementation and doesn't cover everything, but the most common use cases. (Can be used for the suggested headers change later)

## Notes
The `Proplist` module tries to maintain all non-tuple like items (i.e `[:a, :b, {:c, 3}]`, where :a and :b are not tuples) to the best of it's ability, while still allowing the use of mixed content (unlike Keyword and pure :proplists, i.e `["text/plain", {"name", "mytext.txt"}]`) 