### PR TITLE
Add parentheses when missing for time zones

### DIFF
--- a/lib/mail/parsers/rfc_2822.ex
+++ b/lib/mail/parsers/rfc_2822.ex
@@ -79,6 +79,23 @@ defmodule Mail.Parsers.RFC2822 do
 
     {{year, month, date}, {hour, minute, second}}
   end
+  def erl_from_timestamp(<<
+                         date  ::  binary-size(2),
+                         " ",
+                         month :: binary-size(3),
+                         " ",
+                         year :: binary-size(4),
+                         " ",
+                         hour :: binary-size(2),
+                         ":",
+                         minute :: binary-size(2),
+                         ":",
+                         second :: binary-size(2),
+                         " ",
+                         timezone :: binary-size(3),
+                         _rest :: binary>>) do
+    erl_from_timestamp(date <> " " <> month <> " " <> year <> " " <> hour <> ":" <> minute <> ":" <> second <> " (" <> timezone <> ")")
+  end  
 
   defp parse_headers(message, []), do: message
   defp parse_headers(message, [header | tail]) do

--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -101,6 +101,7 @@ defmodule Mail.Parsers.RFC2822Test do
     assert erl_from_timestamp("\t1 Apr 2016 22:33:44 +0000") == {{2016, 4, 1}, {22,33,44}}
     assert erl_from_timestamp("12 Jan 2016 00:00:00 +0000") == {{2016, 1, 12}, {0,0,0}}
     assert erl_from_timestamp("25 Dec 2016 00:00:00 +0000 (UTC)") == {{2016, 12, 25}, {0,0,0}}
+    assert erl_from_timestamp("03 Apr 2017 12:30:55 GMT") == {{2017, 04, 03}, {12,30,55}}
   end
 
   test "parses a nested multipart message with encoded part" do


### PR DESCRIPTION
## Changes proposed in this pull request
In our usage of this library, we are seeing some timestamps in the format 
```
03 Apr 2017 12:30:55 GMT
```

where the timezone does not include parentheses.  This is a quick fix to add parentheses so that this will match the pattern on line 57