### PR TITLE
Changed Courier name to Mail in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An RFC2822 implementation in Elixir, built for composability.
 
-**[Courier is built and maintained by DockYard, contact us for expert Elixir and Phoenix consulting](https://dockyard.com/phoenix-consulting)**.
+**[Mail is built and maintained by DockYard, contact us for expert Elixir and Phoenix consulting](https://dockyard.com/phoenix-consulting)**.
 
 ## Building
 


### PR DESCRIPTION
Was unsure if project is officially called `elixir-mail` or `mail`, since it's different on github and hex. But it surely isn't `Courier`