### PR TITLE
Fix quoted-printable encoding

### DIFF
--- a/lib/mail/encoder.ex
+++ b/lib/mail/encoder.ex
@@ -8,7 +8,7 @@ defmodule Mail.Encoder do
   @spec encoder_for(encoding :: String.t | atom) :: atom
   def encoder_for(encoding) when is_atom(encoding) do
     encoding
-    |> Atom.to_string()
+    |> normalize()
     |> encoder_for()
   end
 
@@ -27,4 +27,8 @@ defmodule Mail.Encoder do
 
   @spec decode(data :: binary, encoding :: String.t) :: binary
   def decode(data, encoding), do: encoder_for(encoding).decode(data)
+
+  defp normalize(:quoted_printable), do: normalize(:"quoted-printable")
+  defp normalize(encoding) when is_atom(encoding), do: Atom.to_string(encoding)
+  defp normalize(encoding) when is_binary(encoding), do: encoding
 end

--- a/test/fixtures/recursive-part-rendering.eml
+++ b/test/fixtures/recursive-part-rendering.eml
@@ -4,11 +4,11 @@ Content-Type: multipart/alternative; boundary="foobar"
 Content-Type: text/plain
 Content-Transfer-Encoding: quoted-printable
 
-Hello there!
+Hello there! 1 + 1 =3D 2
 
 --foobar
 Content-Type: text/html
 Content-Transfer-Encoding: quoted-printable
 
-<h1>Hello there!</h1>
+<a href=3D"/">Hello there! 1 + 1 =3D 2</a>
 --foobar--

--- a/test/mail/renderers/rfc_2822_test.exs
+++ b/test/mail/renderers/rfc_2822_test.exs
@@ -68,8 +68,8 @@ defmodule Mail.Renderers.RFC2822Test do
   end
 
   test "renders each part recursively" do
-    sub_part_1 = Mail.Message.build_text("Hello there!")
-    sub_part_2 = Mail.Message.build_html("<h1>Hello there!</h1>")
+    sub_part_1 = Mail.Message.build_text("Hello there! 1 + 1 = 2")
+    sub_part_2 = Mail.Message.build_html(~s|<a href="/">Hello there! 1 + 1 = 2</a>|)
 
     part =
       Mail.build_multipart()


### PR DESCRIPTION
The `QUOTED-PRINTABLE` value for the `Content-Transfer-Encoding` header is stored as a underscored atom `quoted_printable`, but the `encoder_for/1` function attempts to map by comparing this value to a dash separated string `"quoted-printable"`. This results in the binary encoder being used by default, which breaks messages with `=` characters (see the changed test case). I kept the underscored mapping in order to keep backwards compatibility of the atom version of `Mail.Message.put_header/3`, which does not replace underscores with dashes.