### PR TITLE
fix reorganize/1: do not return nil for messages without text parts

### DIFF
--- a/lib/mail/renderers/rfc_2822.ex
+++ b/lib/mail/renderers/rfc_2822.ex
@@ -198,6 +198,8 @@ defmodule Mail.Renderers.RFC2822 do
 
         mixed_part = Enum.reduce(text_parts, mixed_part, &(Mail.Message.put_part(&2, &1)))
         put_in(message.parts, List.insert_at(message.parts, 0, mixed_part))
+      else
+        message
       end
     else
       content_type = List.replace_at(content_type, 0, "multipart/alternative")

--- a/test/fixtures/multipart-jpeg-attachment-rendering.eml
+++ b/test/fixtures/multipart-jpeg-attachment-rendering.eml
@@ -1,0 +1,31 @@
+To: user1@example.com
+Subject: Test email
+Mime-Version: 1.0
+From: "User2" <user2@example.com>
+Content-Type: multipart/mixed; boundary="2753118483D4F18DC5FD1F1A"
+
+--2753118483D4F18DC5FD1F1A
+Content-Type: multipart/alternative; boundary="DB28EC13A6576C8F20B92FD0"
+
+--DB28EC13A6576C8F20B92FD0
+Content-Type: text/plain
+Content-Transfer-Encoding: quoted-printable
+
+Some text
+
+--DB28EC13A6576C8F20B92FD0
+Content-Type: text/html
+Content-Transfer-Encoding: quoted-printable
+
+<h1>Some HTML</h1>
+--DB28EC13A6576C8F20B92FD0--
+
+--2753118483D4F18DC5FD1F1A
+Content-Type: image/jpeg
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename=tiny_jpeg.jpg
+
+/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8Q
+EBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=
+
+--2753118483D4F18DC5FD1F1A--

--- a/test/fixtures/multipart-no-text-parts-rendering.eml
+++ b/test/fixtures/multipart-no-text-parts-rendering.eml
@@ -1,0 +1,15 @@
+To: user1@example.com
+Subject: Test email
+Mime-Version: 1.0
+From: user2@example.com
+Content-Type: multipart/mixed; boundary="9B92CC274F0D648613F3DF31"
+
+--9B92CC274F0D648613F3DF31
+Content-Type: image/jpeg
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename=tiny_jpeg.jpg
+
+/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8Q
+EBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=
+
+--9B92CC274F0D648613F3DF31--

--- a/test/mail/renderers/rfc_2822_test.exs
+++ b/test/mail/renderers/rfc_2822_test.exs
@@ -2,6 +2,13 @@ defmodule Mail.Renderers.RFC2822Test do
   use ExUnit.Case, async: true
   import Mail.Assertions.RFC2822
 
+  # from https://github.com/mathiasbynens/small/blob/master/jpeg.jpg
+  @tiny_jpeg_binary <<255, 216, 255, 219, 0, 67, 0, 3, 2, 2, 2, 2, 2, 3, 2, 2, 2, 3, 3, 3, 3, 4, 6,
+      4, 4, 4, 4, 4, 8, 6, 6, 5, 6, 9, 8, 10, 10, 9, 8, 9, 9, 10, 12, 15, 12, 10,
+      11, 14, 11, 9, 9, 13, 17, 13, 14, 15, 16, 16, 17, 16, 10, 12, 18, 19, 18, 16,
+      19, 15, 16, 16, 16, 255, 201, 0, 11, 8, 0, 1, 0, 1, 1, 1, 17, 0, 255, 204, 0,
+      6, 0, 16, 16, 5, 255, 218, 0, 8, 1, 1, 0, 0, 63, 0, 210, 207, 32, 255, 217>>
+
   test "header - capitalizes and hyphenates keys, joins lists according to spec" do
     header = Mail.Renderers.RFC2822.render_header("foo_bar", ["abcd", baz_buzz: "qux"])
     assert header == "Foo-Bar: abcd; baz-buzz=qux"
@@ -110,6 +117,38 @@ defmodule Mail.Renderers.RFC2822Test do
       |> Mail.Message.put_boundary("foobar")
 
     {:ok, fixture} = File.read("test/fixtures/simple-multipart-rendering.eml")
+
+    result = Mail.Renderers.RFC2822.render(message)
+
+    assert_rfc2822_equal(result, fixture)
+  end
+
+  test "renders a multipart mail with jpeg attachment" do
+    message =
+      Mail.build_multipart()
+      |> Mail.put_to("user1@example.com")
+      |> Mail.put_from({"User2", "user2@example.com"})
+      |> Mail.put_subject("Test email")
+      |> Mail.put_text("Some text")
+      |> Mail.put_html("<h1>Some HTML</h1>")
+      |> Mail.put_attachment({"tiny_jpeg.jpg", @tiny_jpeg_binary})
+
+    {:ok, fixture} = File.read("test/fixtures/multipart-jpeg-attachment-rendering.eml")
+
+    result = Mail.Renderers.RFC2822.render(message)
+
+    assert_rfc2822_equal(result, fixture)
+  end
+
+  test "renders a multipart mail consisting of an attachment only, no text parts" do
+    message =
+      Mail.build_multipart()
+      |> Mail.put_to("user1@example.com")
+      |> Mail.put_from("user2@example.com")
+      |> Mail.put_subject("Test email")
+      |> Mail.put_attachment({"tiny_jpeg.jpg", @tiny_jpeg_binary})
+
+    {:ok, fixture} = File.read("test/fixtures/multipart-no-text-parts-rendering.eml")
 
     result = Mail.Renderers.RFC2822.render(message)
 


### PR DESCRIPTION
<!--
Thank you for contributing!

Here are a few things that will increase the chance that your pull request will get accepted:
 - Write tests, preferably in a test driven style.
 - Add documentation for the changes you made.
 - Follow our styleguide: https://github.com/dockyard/styleguides
-->

<!-- If this pull request addresses an issue please provide the issue number here -->

## Changes proposed in this pull request
<!-- Please describe here what this pull request changes -->
enable rendering of multipart messages that do not contain text parts