### PR TITLE
Fixed render_header_value eternal loop if a value of nil is present

### DIFF
--- a/lib/mail/renderers/rfc_2822.ex
+++ b/lib/mail/renderers/rfc_2822.ex
@@ -114,7 +114,7 @@ defmodule Mail.Renderers.RFC2822 do
   defp render_header_value(_key, [value | subtypes]),
     do: Enum.join([value | render_subtypes(subtypes)], "; ")
 
-  defp render_header_value(key, value),
+  defp render_header_value(key, value) when not is_list(value),
     do: render_header_value(key, List.wrap(value))
 
   defp validate_address(address) do


### PR DESCRIPTION
Found a terrible bug in prod.

I use `render_header` directly for some internal stuff, and found that if you pass nil in as the value, it loops forever

It was a really bad evening...

## Changes proposed in this pull request

A fix for an eternal loop in render_header_value
