### PR TITLE
Parse of "received" headers; keep all entries

### DIFF
--- a/lib/mail/parsers/rfc_2822.ex
+++ b/lib/mail/parsers/rfc_2822.ex
@@ -100,7 +100,7 @@ defmodule Mail.Parsers.RFC2822 do
   end
   
   defp put_header(headers, "received" = key, value),
-    do: Map.update(headers, key, [],  &[value | &1])
+    do: Map.update(headers, key, [value],  &[value | &1])
   defp put_header(headers, key, value),
     do: Map.put(headers, key, value)
 

--- a/lib/mail/parsers/rfc_2822.ex
+++ b/lib/mail/parsers/rfc_2822.ex
@@ -94,10 +94,15 @@ defmodule Mail.Parsers.RFC2822 do
   defp parse_headers(message, [header | tail]) do
     [name, body] = String.split(header, ":", parts: 2)
     key = String.downcase(name)
-    headers = Map.put(message.headers, key, parse_header_value(name, body))
+    headers = put_header(message.headers, key, parse_header_value(name, body))
     message = %{message | headers: headers}
     parse_headers(message, tail)
   end
+  
+  defp put_header(headers, "received" = key, value),
+    do: Map.update(headers, key, [],  &[value | &1])
+  defp put_header(headers, key, value),
+    do: Map.put(headers, key, value)
 
   defp mark_multipart(message),
     do: Map.put(message, :multipart, multipart?(message.headers))


### PR DESCRIPTION
I had interest in maintaining a complete record of them in an experiment I'm working on, and thus needed some way to store them.  RFC2822 mentions that the trace fields will contain "one or more Received: fields."

This is slightly related to #79.  In order to find the "for" value in the trace, you need all of the received headers.
