### PR TITLE
Fix invalid base64 encoding which broke in earlier version of Erlang

### DIFF
--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -359,7 +359,7 @@ defmodule Mail.Parsers.RFC2822Test do
 
       ------=_Part_295474_20544590.1456382229928
       Content-Type: image/png
-      Content-Disposition: attachment; filename=Emoji =?utf-8?B?8J+YgA=?= Filename.png
+      Content-Disposition: attachment; filename=Emoji =?utf-8?B?8J+YgA==?= Filename.png
 
       iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==
       ------=_Part_295474_20544590.1456382229928--


### PR DESCRIPTION
This fixes an encoded-word test that used an invalid base64 encoding that broke on earlier versions of Erlang