### PR TITLE
Fix documentation typo, referred to wrong RFC

### DIFF
--- a/lib/mail/renderers/rfc_2822.ex
+++ b/lib/mail/renderers/rfc_2822.ex
@@ -72,7 +72,7 @@ defmodule Mail.Renderers.RFC2822 do
     do: Enum.map(parts, &fun.(&1))
 
   @doc """
-  Will render a given header according to the RFC2882 spec
+  Will render a given header according to the RFC2822 spec
   """
   def render_header(key, value)
 


### PR DESCRIPTION
Just a typo fix