### PR TITLE
Add allowance for optional seconds and handle invalid hour in time

### DIFF
--- a/lib/mail/parsers/rfc_2822.ex
+++ b/lib/mail/parsers/rfc_2822.ex
@@ -58,6 +58,15 @@ defmodule Mail.Parsers.RFC2822 do
     erl_from_timestamp("0" <> date <> " " <> rest)
   end
 
+  # This caters for invalid date with no 0 before the hour, e.g. 5:21:43 instead of 05:21:43
+  def erl_from_timestamp(<<date::binary-size(11), " ", hour::binary-size(1), ":", rest::binary>>) do
+    erl_from_timestamp("#{date} 0#{hour}:#{rest}")
+  end
+
+  def erl_from_timestamp(<<date::binary-size(11), " ", hour::binary-size(2), ":", minute::binary-size(2), " ", rest::binary>>) do
+    erl_from_timestamp("#{date} #{hour}:#{minute}:00 #{rest}")
+  end
+
   def erl_from_timestamp(
         <<date::binary-size(2), " ", month::binary-size(3), " ", year::binary-size(4), " ",
           hour::binary-size(2), ":", minute::binary-size(2), ":", second::binary-size(2), " ",

--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -112,7 +112,15 @@ defmodule Mail.Parsers.RFC2822Test do
     assert erl_from_timestamp("\t1 Apr 2016 22:33:44 +0000") == {{2016, 4, 1}, {22, 33, 44}}
     assert erl_from_timestamp("12 Jan 2016 00:00:00 +0000") == {{2016, 1, 12}, {0, 0, 0}}
     assert erl_from_timestamp("25 Dec 2016 00:00:00 +0000 (UTC)") == {{2016, 12, 25}, {0, 0, 0}}
-    assert erl_from_timestamp("03 Apr 2017 12:30:55 GMT") == {{2017, 04, 03}, {12, 30, 55}}
+    assert erl_from_timestamp("03 Apr 2017 12:30:55 GMT") == {{2017, 4, 3}, {12, 30, 55}}
+    # The spec specifies that the seconds are optional
+    assert erl_from_timestamp("14 Jun 2019 11:24 +0000") == {{2019, 6, 14}, {11, 24, 0}}
+  end
+
+  test "erl_from_timestamp\1 with invalid RFC2822 timestamps (found in the wild)" do
+    import Mail.Parsers.RFC2822, only: [erl_from_timestamp: 1]
+
+    assert erl_from_timestamp("Thu, 16 May 2019 5:50:53 +0700") == {{2019, 5, 16}, {5, 50, 53}}
   end
 
   test "parses a nested multipart message with encoded part" do


### PR DESCRIPTION
While parsing 10,000 emails I came across a problem with emails that had a single digit hour in their timestamp.
When re-reading the spec I saw that, while the hour is supposed to be 2 digit, the seconds are optional so I have updated the parser to allow for both.