### PR TITLE
Update parsing Received header to handle invalid/missing date part

### DIFF
--- a/lib/mail/parsers/rfc_2822.ex
+++ b/lib/mail/parsers/rfc_2822.ex
@@ -197,8 +197,11 @@ defmodule Mail.Parsers.RFC2822 do
   end
 
   defp parse_received_value(value) do
-    [value | [date]] = String.split(value, ~r/;\s*/)
-    [value | [{"date", erl_from_timestamp(date)}]]
+    case String.split(value, ";") do
+      [value, date] ->
+        [value, {"date", erl_from_timestamp(date)}]
+      value -> value
+    end
   end
 
   defp parse_header_subtypes([]), do: []

--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -380,6 +380,26 @@ defmodule Mail.Parsers.RFC2822Test do
              part.headers["content-disposition"]
   end
 
+  test "parse invalid Received header" do
+    message =
+      parse_email("""
+      Received: by 2002:a81:578e:0:0:0:0:0 with SMTP id l136csp2273163ywb;
+        Sat, 22 Jun 2019 17:59:49 -0700 (PDT)
+      Received: by filter0419p1iad2.sendgrid.net with SMTP id filter0419p1iad2-17662-5D0ECF02-32
+        2019-06-23 00:59:46.828888551 +0000 UTC m=+266323.963383415
+      To: user@example.com
+      From: me@example.com
+      Subject: Test
+
+      Body
+      """)
+
+    assert message.headers["received"] == [
+      ["by filter0419p1iad2.sendgrid.net with SMTP id filter0419p1iad2-17662-5D0ECF02-32  2019-06-23 00:59:46.828888551 +0000 UTC m=+266323.963383415"],
+      ["by 2002:a81:578e:0:0:0:0:0 with SMTP id l136csp2273163ywb", {"date", {{2019, 6, 22}, {17, 59, 49}}}]
+    ]
+  end
+
   defp parse_email(email),
     do: email |> convert_crlf |> Mail.Parsers.RFC2822.parse()
 


### PR DESCRIPTION
This handles a situation found in the wild where a Received header didn’t split the date part with a ';'