### PR TITLE
Bug structured header parsing

### DIFF
--- a/lib/mail/parsers/rfc_2822.ex
+++ b/lib/mail/parsers/rfc_2822.ex
@@ -197,8 +197,11 @@ defmodule Mail.Parsers.RFC2822 do
   end
 
   defp parse_received_value(value) do
-    [value | [date]] = String.split(value, ~r/;\s*/)
-    [value | [{"date", erl_from_timestamp(date)}]]
+    case String.split(value, ";") do
+      [value, date] ->
+        [value, {"date", erl_from_timestamp(date)}]
+      value -> value
+    end
   end
 
   defp parse_header_subtypes([]), do: []

--- a/lib/mail/parsers/rfc_2822.ex
+++ b/lib/mail/parsers/rfc_2822.ex
@@ -206,6 +206,8 @@ defmodule Mail.Parsers.RFC2822 do
 
   defp parse_header_subtypes([]), do: []
 
+  defp parse_header_subtypes(["" | []]), do: []
+
   defp parse_header_subtypes([subtype | tail]) do
     [key, value] = String.split(subtype, "=", parts: 2)
     key = key_to_atom(key)

--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -9,7 +9,7 @@ defmodule Mail.Parsers.RFC2822Test do
       Reply-To: otherme@example.com
       Subject: Test Email
       Content-Type: text/plain; foo=bar;
-        baz=qux
+        baz=qux;
 
       This is the body!
       It has more than one line
@@ -378,6 +378,21 @@ defmodule Mail.Parsers.RFC2822Test do
 
     assert ["attachment", {"filename", "Emoji 😀 Filename.png"}] =
              part.headers["content-disposition"]
+  end
+
+  test "parses structured header with extraneous semicolon" do
+    message =
+      parse_email("""
+      To: user@example.com
+      From: me@example.com
+      Subject: Test
+      Content-Type: text/plain;
+        charset=utf-8;
+
+      This is some text
+      """)
+
+    assert message.body == "This is some text"
   end
 
   test "parse invalid Received header" do

--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -380,6 +380,26 @@ defmodule Mail.Parsers.RFC2822Test do
              part.headers["content-disposition"]
   end
 
+  test "parse invalid Received header" do
+    message =
+      parse_email("""
+      Received: by 2002:a81:578e:0:0:0:0:0 with SMTP id l136csp2273163ywb;
+        Sat, 22 Jun 2019 17:59:49 -0700 (PDT)
+      Received: by filter0419p1iad2.sendgrid.net with SMTP id filter0419p1iad2-17662-5D0ECF02-32
+        2019-06-23 00:59:46.828888551 +0000 UTC m=+266323.963383415
+      To: user@example.com
+      From: me@example.com
+      Subject: Test
+
+      Body
+      """)
+
+    assert message.headers["received"] == [
+      ["by filter0419p1iad2.sendgrid.net with SMTP id filter0419p1iad2-17662-5D0ECF02-32  2019-06-23 00:59:46.828888551 +0000 UTC m=+266323.963383415"],
+      ["by 2002:a81:578e:0:0:0:0:0 with SMTP id l136csp2273163ywb", {"date", {{2019, 6, 22}, {17, 59, 49}}}]
+    ]
+  end
+
   defp parse_email(email),
     do: email |> convert_crlf |> Mail.Parsers.RFC2822.parse()
 


### PR DESCRIPTION
This deals with structured headers that have a trailing semicolon:
```
Content-Type: text/plain;
   charset=utf-8;
```
instead of
```
Content-Type: text/plain;
   charset=utf-8
```