### PR TITLE
Update get_attachments

### DIFF
--- a/lib/mail.ex
+++ b/lib/mail.ex
@@ -170,7 +170,7 @@ defmodule Mail do
     walk_parts([message], {:cont, []}, fn message, acc ->
       case Mail.Message.is_attachment?(message) do
         true ->
-          ["attachment", {"filename", filename}] =
+          ["attachment" | [{"filename", filename} | _]] =
             Mail.Message.get_header(message, :content_disposition)
 
           {:cont, List.insert_at(acc, -1, {filename, message.body})}

--- a/lib/mail.ex
+++ b/lib/mail.ex
@@ -170,7 +170,7 @@ defmodule Mail do
     walk_parts([message], {:cont, []}, fn message, acc ->
       case Mail.Message.is_attachment?(message) do
         true ->
-          ["attachment" | [{"filename", filename} | _]] =
+          ["attachment", {"filename", filename} | _] =
             Mail.Message.get_header(message, :content_disposition)
 
           {:cont, List.insert_at(acc, -1, {filename, message.body})}

--- a/test/mail_test.exs
+++ b/test/mail_test.exs
@@ -371,6 +371,24 @@ defmodule MailTest do
     assert attachments == expected
   end
 
+  test "get_attachments handles content disposition header with extra properties" do
+    {filename, data} = file = {"README.md", File.read!("README.md")}
+
+    mail =
+      Mail.build()
+      |> Mail.Message.put_body(data)
+      |> Mail.Message.put_header(:content_disposition, [
+        "attachment",
+        {"filename", filename},
+        {"size", "xxx"},
+        {"creation_date", "xxx"}
+      ])
+      |> Mail.Message.put_header(:content_transfer_encoding, :base64)
+
+    [attachment | _] = Mail.get_attachments(mail)
+    assert attachment == file
+  end
+
   test "renders with the given renderer" do
     result =
       Mail.build()


### PR DESCRIPTION
Some emails can contain properties in the 'content-disposition' header value such as size, creation date, modification date, and read date.
This prevents the following error:
```
 **(MatchError) no match of right hand side value: ["attachment", {"filename", "test.txt"}, {"size", "xxx"}, {"creation_date", "xxx"}, {"modification_date", "xxx"}]
    (mail) lib/mail.ex:173: anonymous fn/2 in Mail.get_attachments/1
    (mail) lib/mail.ex:189: Mail.walk_parts/3
    (mail) lib/mail.ex:190: Mail.walk_parts/3
    (mail) lib/mail.ex:170: Mail.get_attachments/1
```
