### PR TITLE
RFC2822 parse recipient value is now part of public API

### DIFF
--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -123,6 +123,29 @@ defmodule Mail.Parsers.RFC2822Test do
     assert erl_from_timestamp("Thu, 16 May 2019 5:50:53 +0700") == {{2019, 5, 16}, {5, 50, 53}}
   end
 
+  test "parse_recipient_value retrieves a list of name and addresses" do
+    recipient = "The Dude <dude@example.com>, batman@example.com"
+
+    retrieved_recipients = [
+      {"The Dude", "dude@example.com"},
+      "batman@example.com"
+    ]
+
+    assert parse_recipient(recipient) == retrieved_recipients
+  end
+
+  test "parse_recipient_value retrieves an empty list when recipient is empty" do
+    assert parse_recipient("") == []
+  end
+
+  test "parse_recipient_value retrieves an empty list when no \"address\" found" do
+    assert parse_recipient("NoEmail") == []
+  end
+
+  test "parse_recipient_value retrieves a list when only one \"address\" found" do
+    assert parse_recipient("dude@example.com") == ["dude@example.com"]
+  end
+
   test "parses a nested multipart message with encoded part" do
     message =
       parse_email("""
@@ -572,6 +595,9 @@ defmodule Mail.Parsers.RFC2822Test do
 
   defp parse_email(email),
     do: email |> convert_crlf |> Mail.Parsers.RFC2822.parse()
+
+  defp parse_recipient(recipient),
+    do: Mail.Parsers.RFC2822.parse_recipient_value(recipient)
 
   def convert_crlf(text),
     do: text |> String.replace("\n", "\r\n")


### PR DESCRIPTION
#103 

## Changes proposed in this pull request

This pull request makes makes the `parse_recipient_value` a public function.
This function has value outside of the context of parsing a full email, since email addresses can be found in other context and are hard to split in their name/address parts.

Since the function is now public, tests and documentation have been added

## Notes

- Regarding how to contribute, I'm not entirely sure if I should also update the changelog
- There is the option of exposing the function in the `Mail` module, but I'm not sure if this is desired

Cheers. Sorry it took so long!
