### PR TITLE
Add options to some functions

### DIFF
--- a/lib/mail.ex
+++ b/lib/mail.ex
@@ -120,17 +120,19 @@ defmodule Mail do
 
   Each call will add a new attachment part.
   """
-  def put_attachment(%Mail.Message{multipart: true} = message, path) when is_binary(path),
-    do: Mail.Message.put_part(message, Mail.Message.build_attachment(path))
+  def put_attachment(message, path, additional_values \\ [])
 
-  def put_attachment(%Mail.Message{multipart: true} = message, {filename, data}),
-    do: Mail.Message.put_part(message, Mail.Message.build_attachment({filename, data}))
+  def put_attachment(%Mail.Message{multipart: true} = message, path, additional_values) when is_binary(path),
+    do: Mail.Message.put_part(message, Mail.Message.build_attachment(path, additional_values))
 
-  def put_attachment(%Mail.Message{} = message, path) when is_binary(path),
-    do: Mail.Message.put_attachment(message, path)
+  def put_attachment(%Mail.Message{multipart: true} = message, {filename, data}, additional_values),
+    do: Mail.Message.put_part(message, Mail.Message.build_attachment({filename, data}, additional_values))
 
-  def put_attachment(%Mail.Message{} = message, {filename, data}),
-    do: Mail.Message.put_attachment(message, {filename, data})
+  def put_attachment(%Mail.Message{} = message, path, additional_values) when is_binary(path),
+    do: Mail.Message.put_attachment(message, path, additional_values)
+
+  def put_attachment(%Mail.Message{} = message, {filename, data}, additional_values),
+    do: Mail.Message.put_attachment(message, {filename, data}, additional_values)
 
   @doc """
   Determines the message has any attachment parts

--- a/lib/mail.ex
+++ b/lib/mail.ex
@@ -35,20 +35,21 @@ defmodule Mail do
   If a text part already exists this function will replace that existing
   part with the new part.
   """
-  def put_text(%Mail.Message{multipart: true} = message, body) do
+  def put_text(message, body, additional_values \\ [])
+  def put_text(%Mail.Message{multipart: true} = message, body, additional_values) do
     message =
       case Enum.find(message.parts, &Mail.Message.match_body_text/1) do
         %Mail.Message{} = part -> Mail.Message.delete_part(message, part)
         _ -> message
       end
 
-    Mail.Message.put_part(message, Mail.Message.build_text(body))
+    Mail.Message.put_part(message, Mail.Message.build_text(body, additional_values))
   end
 
-  def put_text(%Mail.Message{} = message, body) do
+  def put_text(%Mail.Message{} = message, body, additional_values) do
     Mail.Message.put_body(message, body)
     |> Mail.Message.put_header(:content_transfer_encoding, :quoted_printable)
-    |> Mail.Message.put_content_type("text/plain")
+    |> Mail.Message.put_content_type("text/plain", additional_values)
   end
 
   @doc """

--- a/lib/mail.ex
+++ b/lib/mail.ex
@@ -35,21 +35,21 @@ defmodule Mail do
   If a text part already exists this function will replace that existing
   part with the new part.
   """
-  def put_text(message, body, additional_values \\ [])
-  def put_text(%Mail.Message{multipart: true} = message, body, additional_values) do
+  def put_text(message, body, opts \\ [])
+  def put_text(%Mail.Message{multipart: true} = message, body, opts) do
     message =
       case Enum.find(message.parts, &Mail.Message.match_body_text/1) do
         %Mail.Message{} = part -> Mail.Message.delete_part(message, part)
         _ -> message
       end
 
-    Mail.Message.put_part(message, Mail.Message.build_text(body, additional_values))
+    Mail.Message.put_part(message, Mail.Message.build_text(body, opts))
   end
 
-  def put_text(%Mail.Message{} = message, body, additional_values) do
+  def put_text(%Mail.Message{} = message, body, opts) do
     Mail.Message.put_body(message, body)
     |> Mail.Message.put_header(:content_transfer_encoding, :quoted_printable)
-    |> Mail.Message.put_content_type("text/plain", additional_values)
+    |> Mail.Message.put_content_type("text/plain", opts)
   end
 
   @doc """
@@ -120,19 +120,19 @@ defmodule Mail do
 
   Each call will add a new attachment part.
   """
-  def put_attachment(message, path, additional_values \\ [])
+  def put_attachment(message, path, opts \\ [])
 
-  def put_attachment(%Mail.Message{multipart: true} = message, path, additional_values) when is_binary(path),
-    do: Mail.Message.put_part(message, Mail.Message.build_attachment(path, additional_values))
+  def put_attachment(%Mail.Message{multipart: true} = message, path, opts) when is_binary(path),
+    do: Mail.Message.put_part(message, Mail.Message.build_attachment(path, opts))
 
-  def put_attachment(%Mail.Message{multipart: true} = message, {filename, data}, additional_values),
-    do: Mail.Message.put_part(message, Mail.Message.build_attachment({filename, data}, additional_values))
+  def put_attachment(%Mail.Message{multipart: true} = message, {filename, data}, opts),
+    do: Mail.Message.put_part(message, Mail.Message.build_attachment({filename, data}, opts))
 
-  def put_attachment(%Mail.Message{} = message, path, additional_values) when is_binary(path),
-    do: Mail.Message.put_attachment(message, path, additional_values)
+  def put_attachment(%Mail.Message{} = message, path, opts) when is_binary(path),
+    do: Mail.Message.put_attachment(message, path, opts)
 
-  def put_attachment(%Mail.Message{} = message, {filename, data}, additional_values),
-    do: Mail.Message.put_attachment(message, {filename, data}, additional_values)
+  def put_attachment(%Mail.Message{} = message, {filename, data}, opts),
+    do: Mail.Message.put_attachment(message, {filename, data}, opts)
 
   @doc """
   Determines the message has any attachment parts

--- a/lib/mail/message.ex
+++ b/lib/mail/message.ex
@@ -50,16 +50,20 @@ defmodule Mail.Message do
   @doc """
   Add a new header key/value pair
 
-      Mail.Message.put_header(%Mail.Message{}, :content_type, "text/plain")
+      Mail.Message.put_header(%Mail.Message{}, :content_type, "text/plain", charset: "UTF-8")
 
   The individual headers will be in the `headers` field on the
   `%Mail.Message{}` struct
   """
-  def put_header(message, key, content) when not is_binary(key),
-    do: put_header(message, to_string(key), content)
+  def put_header(message, key, content, additional_values \\ [])
+  def put_header(message, key, content, additional_values) when not is_binary(key),
+    do: put_header(message, to_string(key), content, additional_values)
 
-  def put_header(message, key, content),
+  def put_header(message, key, content, []),
     do: %{message | headers: Map.put(message.headers, fix_header(key), content)}
+
+  def put_header(message, key, content, additional_values),
+    do: %{message | headers: Map.put(message.headers, fix_header(key), put_additional_values(content, additional_values))}
 
   def get_header(message, key) when not is_binary(key),
     do: get_header(message, to_string(key))

--- a/test/mail/message_test.exs
+++ b/test/mail/message_test.exs
@@ -132,6 +132,16 @@ defmodule Mail.MessageTest do
     assert message.body == "<h1>Some HTML</h1>"
   end
 
+  test "build_attachment with additional_values" do
+    message = Mail.Message.build_attachment("README.md", content_transfer_encoding: :quoted_printable, filename: "renamed_README.md")
+
+    assert Mail.Message.get_header(message, :content_disposition) == [
+             "attachment",
+             {"filename", "renamed_README.md"}
+           ]
+    assert Mail.Message.get_header(message, :content_transfer_encoding) == :quoted_printable
+  end
+
   test "build_attachment when given a path" do
     part = Mail.Message.build_attachment("README.md")
     {:ok, file_content} = File.read("README.md")

--- a/test/mail/message_test.exs
+++ b/test/mail/message_test.exs
@@ -118,6 +118,13 @@ defmodule Mail.MessageTest do
     assert message.body == "Some text"
   end
 
+  test "build_text with additional values" do
+    message = Mail.Message.build_text("Some text", charset: "UTF-8", format: :flowed, content_transfer_encoding: :base64)
+    assert Mail.Message.get_content_type(message) == ["text/plain", {"charset", "UTF-8"}, {"format", "flowed"}]
+    assert Mail.Message.get_header(message, :content_transfer_encoding) == :base64
+    assert message.body == "Some text"
+  end
+
   test "build_html" do
     message = Mail.Message.build_html("<h1>Some HTML</h1>")
     assert Mail.Message.get_content_type(message) == ["text/html"]

--- a/test/mail/message_test.exs
+++ b/test/mail/message_test.exs
@@ -28,6 +28,11 @@ defmodule Mail.MessageTest do
     assert Mail.Message.get_header(message, :test) == "test content"
   end
 
+  test "put_header with additional values" do
+    message = Mail.Message.put_header(%Mail.Message{}, :test, "test content", charset: "UTF-8", format: :flowed)
+    assert Mail.Message.get_header(message, :test) == ["test content", {"charset", "UTF-8"}, {"format", "flowed"}]
+  end
+
   test "get_header" do
     message = %Mail.Message{headers: %{"foo" => "bar"}}
     assert Mail.Message.get_header(message, :foo) == "bar"

--- a/test/mail/message_test.exs
+++ b/test/mail/message_test.exs
@@ -28,7 +28,7 @@ defmodule Mail.MessageTest do
     assert Mail.Message.get_header(message, :test) == "test content"
   end
 
-  test "put_header with additional values" do
+  test "put_header with options" do
     message = Mail.Message.put_header(%Mail.Message{}, :test, "test content", charset: "UTF-8", format: :flowed)
     assert Mail.Message.get_header(message, :test) == ["test content", {"charset", "UTF-8"}, {"format", "flowed"}]
   end
@@ -118,7 +118,7 @@ defmodule Mail.MessageTest do
     assert message.body == "Some text"
   end
 
-  test "build_text with additional values" do
+  test "build_text with options" do
     message = Mail.Message.build_text("Some text", charset: "UTF-8", format: :flowed, content_transfer_encoding: :base64)
     assert Mail.Message.get_content_type(message) == ["text/plain", {"charset", "UTF-8"}, {"format", "flowed"}]
     assert Mail.Message.get_header(message, :content_transfer_encoding) == :base64
@@ -132,7 +132,7 @@ defmodule Mail.MessageTest do
     assert message.body == "<h1>Some HTML</h1>"
   end
 
-  test "build_attachment with additional_values" do
+  test "build_attachment with opts" do
     message = Mail.Message.build_attachment("README.md", content_transfer_encoding: :quoted_printable, filename: "renamed_README.md")
 
     assert Mail.Message.get_header(message, :content_disposition) == [


### PR DESCRIPTION
Had some problems with different email-clients that required setting additional values on some headers. 
## Changes proposed in this pull request
* Add options to `Mail.put_text` and `Mail.Message.build_text`
* Add options to `Mail.put_attachment` and `Mail.Message.build_attachment`
* Add options to `Mail.put_text` and `Mail.Message.build_text`
* add options to `Mail.Message.put_header`
* add options to `Mail.Message.put_content_type`