### PR TITLE
Part without body

### DIFF
--- a/lib/mail/parsers/rfc_2822.ex
+++ b/lib/mail/parsers/rfc_2822.ex
@@ -391,6 +391,10 @@ defmodule Mail.Parsers.RFC2822 do
     Map.put(message, :parts, parts)
   end
 
+  defp parse_body(%Mail.Message{} = message, []) do
+    message
+  end
+
   defp parse_body(%Mail.Message{} = message, lines) do
     decoded =
       lines

--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -23,6 +23,22 @@ defmodule Mail.Parsers.RFC2822Test do
     assert message.body == "This is the body!\r\nIt has more than one line"
   end
 
+  test "parses a singlepart message with no body" do
+    message =
+      parse_email("""
+      To: user@example.com
+      From: me@example.com
+      Reply-To: otherme@example.com
+      Subject: Test Email
+      """)
+
+    assert message.headers["to"] == ["user@example.com"]
+    assert message.headers["from"] == "me@example.com"
+    assert message.headers["reply-to"] == "otherme@example.com"
+    assert message.headers["subject"] == "Test Email"
+    assert message.body == nil
+  end
+
   test "parses a multipart message" do
     message =
       parse_email("""

--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -606,6 +606,7 @@ defmodule Mail.Parsers.RFC2822Test do
       """)
 
     assert message.parts == []
+    assert message.body == nil
   end
 
   test "content-type with implicit charset" do

--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -89,18 +89,25 @@ defmodule Mail.Parsers.RFC2822Test do
       Content-Type: text/html
 
       <h1>This is some HTML</h1>
+
+      --foobar
+      x-my-header: no body!
+
       --foobar--
       """)
 
     assert message.body == nil
 
-    [text_part, html_part] = message.parts
+    [text_part, html_part, headers_only_part] = message.parts
 
     assert text_part.headers["content-type"] == "text/plain"
     assert text_part.body == "This is some text"
 
     assert html_part.headers["content-type"] == "text/html"
     assert html_part.body == "<h1>This is some HTML</h1>"
+
+    assert headers_only_part.headers["x-my-header"] == "no body!"
+    assert headers_only_part.body == nil
   end
 
   test "erl_from_timestamp\1" do


### PR DESCRIPTION
## Changes proposed in this pull request

As per [section 2.1 of RFC 2822](https://tools.ietf.org/html/rfc2822#section-2.1) it is possible for a part to not have a body:

> A message consists of header fields (collectively called "the header of the message") followed, **optionally, by a body**.

This PR makes a small change to return a `body` of `nil` in the case where there is no body present, either in a single part email, or a multipart email.