### PR TITLE
Default content-type header

### DIFF
--- a/lib/mail/parsers/rfc_2822.ex
+++ b/lib/mail/parsers/rfc_2822.ex
@@ -18,7 +18,7 @@ defmodule Mail.Parsers.RFC2822 do
     [headers, lines] = extract_headers(lines)
 
     %Mail.Message{}
-    |> parse_headers(headers) |> IO.inspect()
+    |> parse_headers(headers)
     |> mark_multipart
     |> parse_body(lines)
   end
@@ -191,7 +191,7 @@ defmodule Mail.Parsers.RFC2822 do
   end)
 
   defp parse_headers(%Mail.Message{headers: existing_headers} = message, []) do
-    headers = Map.put_new(existing_headers, "content-type", ["text/plain", "us-ascii"])
+    headers = Map.put_new(existing_headers, "content-type", ["text/plain", {"charset", "us-ascii"}])
     %{message | headers: headers}
   end
 

--- a/lib/mail/parsers/rfc_2822.ex
+++ b/lib/mail/parsers/rfc_2822.ex
@@ -18,7 +18,7 @@ defmodule Mail.Parsers.RFC2822 do
     [headers, lines] = extract_headers(lines)
 
     %Mail.Message{}
-    |> parse_headers(headers)
+    |> parse_headers(headers) |> IO.inspect()
     |> mark_multipart
     |> parse_body(lines)
   end
@@ -190,9 +190,12 @@ defmodule Mail.Parsers.RFC2822 do
       do: unquote(month_name)
   end)
 
-  defp parse_headers(message, []), do: message
+  defp parse_headers(%Mail.Message{headers: existing_headers} = message, []) do
+    headers = Map.put_new(existing_headers, "content-type", ["text/plain", "us-ascii"])
+    %{message | headers: headers}
+  end
 
-  defp parse_headers(message, [header | tail]) do
+  defp parse_headers(%Mail.Message{} = message, [header | tail]) do
     [name, body] = String.split(header, ":", parts: 2)
     key = String.downcase(name)
     decoded = parse_encoded_word(body)

--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -626,7 +626,7 @@ defmodule Mail.Parsers.RFC2822Test do
       Subject: Test
       """)
 
-    assert message.headers["content-type"] == ["text/plain", "us-ascii"]
+    assert message.headers["content-type"] == ["text/plain", {"charset", "us-ascii"}]
   end
 
   defp parse_email(email),

--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -618,6 +618,17 @@ defmodule Mail.Parsers.RFC2822Test do
     assert message.headers["content-type"] == ["text/html", "us-ascii"]
   end
 
+  test "implicit content-type and charset" do
+    message =
+      parse_email("""
+      To: user@example.com
+      From: me@example.com
+      Subject: Test
+      """)
+
+    assert message.headers["content-type"] == ["text/plain", "us-ascii"]
+  end
+
   defp parse_email(email),
     do: email |> convert_crlf |> Mail.Parsers.RFC2822.parse()
 

--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -618,7 +618,7 @@ defmodule Mail.Parsers.RFC2822Test do
     assert message.headers["content-type"] == ["text/html", "us-ascii"]
   end
 
-  test "implicit content-type and charset" do
+  test "default text/plain & us-ascii when no content-type header is given" do
     message =
       parse_email("""
       To: user@example.com


### PR DESCRIPTION
## Changes proposed in this pull request

If an email (or a part of a multipart email) has no `content-type` header, a default of `Content-Type: text/plain; charset=us-ascii` is assumed.

---

This is not part of the RFC 2822 but is part of [RFC 1341](https://tools.ietf.org/html/rfc1341):

> If  no  Content-Type  is specified, either by error or by an older user agent, this default is assumed

