### PR TITLE
Add support for attachment's custom headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 erl_crash.dump
 *.ez
 /doc
+.elixir_ls

--- a/lib/mail.ex
+++ b/lib/mail.ex
@@ -121,17 +121,20 @@ defmodule Mail do
 
   Each call will add a new attachment part.
   """
-  def put_attachment(%Mail.Message{multipart: true} = message, path) when is_binary(path),
-    do: Mail.Message.put_part(message, Mail.Message.build_attachment(path))
 
-  def put_attachment(%Mail.Message{multipart: true} = message, {filename, data}),
-    do: Mail.Message.put_part(message, Mail.Message.build_attachment({filename, data}))
+  def put_attachment(message, path_or_file_tuple, opts \\ [])
 
-  def put_attachment(%Mail.Message{} = message, path) when is_binary(path),
-    do: Mail.Message.put_attachment(message, path)
+  def put_attachment(%Mail.Message{multipart: true} = message, path, opts) when is_binary(path),
+    do: Mail.Message.put_part(message, Mail.Message.build_attachment(path, opts))
 
-  def put_attachment(%Mail.Message{} = message, {filename, data}),
-    do: Mail.Message.put_attachment(message, {filename, data})
+  def put_attachment(%Mail.Message{multipart: true} = message, {filename, data}, opts),
+    do: Mail.Message.put_part(message, Mail.Message.build_attachment({filename, data}, opts))
+
+  def put_attachment(%Mail.Message{} = message, path, opts) when is_binary(path),
+    do: Mail.Message.put_attachment(message, path, opts)
+
+  def put_attachment(%Mail.Message{} = message, {filename, data}, opts),
+    do: Mail.Message.put_attachment(message, {filename, data}, opts)
 
   @doc """
   Determines the message has any attachment parts

--- a/test/mail/message_test.exs
+++ b/test/mail/message_test.exs
@@ -135,6 +135,22 @@ defmodule Mail.MessageTest do
     assert part.body == file_content
   end
 
+  test "build_attachment when given a path with headers" do
+    part = Mail.Message.build_attachment("README.md", headers: [content_id: "attachment-id"])
+    {:ok, file_content} = File.read("README.md")
+
+    assert Mail.Message.get_content_type(part) == ["text/markdown"]
+
+    assert Mail.Message.get_header(part, :content_disposition) == [
+             "attachment",
+             {"filename", "README.md"}
+           ]
+
+    assert Mail.Message.get_header(part, :content_transfer_encoding) == :base64
+    assert Mail.Message.get_header(part, :content_id) == "attachment-id"
+    assert part.body == file_content
+  end
+
   test "put_attachment when given a path" do
     part = Mail.Message.put_attachment(%Mail.Message{}, "README.md")
     {:ok, file_content} = File.read("README.md")
@@ -147,6 +163,22 @@ defmodule Mail.MessageTest do
            ]
 
     assert Mail.Message.get_header(part, :content_transfer_encoding) == :base64
+    assert part.body == file_content
+  end
+
+  test "put_attachment when given a path with headers" do
+    part = Mail.Message.put_attachment(%Mail.Message{}, "README.md", headers: [content_id: "attachment-id"])
+    {:ok, file_content} = File.read("README.md")
+
+    assert Mail.Message.get_content_type(part) == ["text/markdown"]
+
+    assert Mail.Message.get_header(part, :content_disposition) == [
+             "attachment",
+             {"filename", "README.md"}
+           ]
+
+    assert Mail.Message.get_header(part, :content_transfer_encoding) == :base64
+    assert Mail.Message.get_header(part, :content_id) == "attachment-id"
     assert part.body == file_content
   end
 


### PR DESCRIPTION
# Changes proposed in this pull request

Add support for custom headers, specially supporting content-id on attachments.