### PR TITLE
Add charset option to text, html part

### DIFF
--- a/lib/mail/message.ex
+++ b/lib/mail/message.ex
@@ -186,24 +186,56 @@ defmodule Mail.Message do
 
       Mail.Message.build_text("Some text")
       %Mail.Message{body: "Some text", headers: %{content_type: "text/plain"}}
+
+      Mail.Message.build_text("Some text", charset: "UTF-8")
+      %Mail.Message{body: "Some text", headers: %{content_type: ["text/plain", {"charset", "UTF-8"}]}}
+
+  ## Options
+
+  * `:charset` - The character encoding standard for content type
   """
-  def build_text(body),
-    do:
-      put_content_type(%Mail.Message{}, "text/plain")
-      |> put_header(:content_transfer_encoding, :quoted_printable)
-      |> put_body(body)
+  def build_text(body, opts \\ []) do
+    content_type =
+      case opts do
+        charset: charset ->
+          ["text/plain", {"charset", charset}]
+
+        _else ->
+          "text/plain"
+      end
+
+    put_content_type(%Mail.Message{}, content_type)
+    |> put_header(:content_transfer_encoding, :quoted_printable)
+    |> put_body(body)
+  end
 
   @doc """
   Build a new HTML message
 
       Mail.Message.build_html("<h1>Some HTML</h1>")
       %Mail.Message{body: "<h1>Some HTML</h1>", headers: %{content_type: "text/html"}}
+
+      Mail.Message.build_html("<h1>Some HTML</h1>", charset: "UTF-8")
+      %Mail.Message{body: "<h1>Some HTML</h1>", headers: %{content_type: ["text/html", {"charset", "UTF-8"}]}}
+
+  ## Options
+
+  * `:charset` - The character encoding standard for content type
   """
-  def build_html(body),
-    do:
-      put_content_type(%Mail.Message{}, "text/html")
-      |> put_header(:content_transfer_encoding, :quoted_printable)
-      |> put_body(body)
+  def build_html(body, opts \\ []) do
+    content_type =
+      case opts do
+        charset: charset ->
+          ["text/html", {"charset", charset}]
+
+        _else ->
+          "text/html"
+      end
+
+    put_content_type(%Mail.Message{}, content_type)
+    |> put_header(:content_transfer_encoding, :quoted_printable)
+    |> put_body(body)
+  end
 
   @doc """
   Add attachment meta data to a `Mail.Message`

--- a/test/mail/message_test.exs
+++ b/test/mail/message_test.exs
@@ -113,9 +113,23 @@ defmodule Mail.MessageTest do
     assert message.body == "Some text"
   end
 
+  test "build_text when given charset" do
+    message = Mail.Message.build_text("Some text", charset: "UTF-8")
+    assert Mail.Message.get_content_type(message) == ["text/plain", {"charset", "UTF-8"}]
+    assert Mail.Message.get_header(message, :content_transfer_encoding) == :quoted_printable
+    assert message.body == "Some text"
+  end
+
   test "build_html" do
     message = Mail.Message.build_html("<h1>Some HTML</h1>")
     assert Mail.Message.get_content_type(message) == ["text/html"]
+    assert Mail.Message.get_header(message, :content_transfer_encoding) == :quoted_printable
+    assert message.body == "<h1>Some HTML</h1>"
+  end
+
+  test "build_html when given charset" do
+    message = Mail.Message.build_html("<h1>Some HTML</h1>", charset: "UTF-8")
+    assert Mail.Message.get_content_type(message) == ["text/html", {"charset", "UTF-8"}]
     assert Mail.Message.get_header(message, :content_transfer_encoding) == :quoted_printable
     assert message.body == "<h1>Some HTML</h1>"
   end


### PR DESCRIPTION
<!--
Thank you for contributing!

Here are a few things that will increase the chance that your pull request will get accepted:
 - Write tests, preferably in a test driven style.
 - Add documentation for the changes you made.
 - Follow our styleguide: https://github.com/dockyard/styleguides
-->

<!-- If this pull request addresses an issue please provide the issue number here -->
Closes #119 

## Changes proposed in this pull request
<!-- Please describe here what this pull request changes -->
- add `:charset` option to put_text, put_html, build_text, build_html
- can receive content type with charset in get_html