### PR TITLE
Fixed get_text and get_html for nested multipart messages

### DIFF
--- a/lib/mail.ex
+++ b/lib/mail.ex
@@ -75,10 +75,9 @@ defmodule Mail do
   If multipart without part having `content-type` "text/plain" will return `nil`
   """
   def get_text(%Mail.Message{multipart: true} = message) do
-    Enum.find(message.parts, fn
-      %Mail.Message{headers: %{"content-type" => "text/plain" <> _}} = message -> message
-      %Mail.Message{headers: %{"content-type" => ["text/plain" | _]}} = message -> message
-      _ -> nil
+    Enum.reduce_while(message.parts, nil, fn sub_message, acc ->
+      text_part = get_text(sub_message)
+      if text_part, do: {:halt, text_part}, else: {:cont, acc}
     end)
   end
 
@@ -138,10 +137,9 @@ defmodule Mail do
   If multipart without part having `content-type` "text/html" will return `nil`
   """
   def get_html(%Mail.Message{multipart: true} = message) do
-    Enum.find(message.parts, fn
-      %Mail.Message{headers: %{"content-type" => "text/html"}} = message -> message
-      %Mail.Message{headers: %{"content-type" => ["text/html", _]}} = message -> message
-      _ -> nil
+    Enum.reduce_while(message.parts, nil, fn sub_message, acc ->
+      html_part = get_html(sub_message)
+      if html_part, do: {:halt, html_part}, else: {:cont, acc}
     end)
   end
 


### PR DESCRIPTION
<!--
Thank you for contributing!

Here are a few things that will increase the chance that your pull request will get accepted:
 - Write tests, preferably in a test driven style.
 - Add documentation for the changes you made.
 - Follow our styleguide: https://github.com/dockyard/styleguides
-->

## Changes proposed in this pull request
<!-- Please describe here what this pull request changes -->

`Mail.get_text` and `Mail.get_html` work incorrectly for mail messages with html or text part in an inner nested multipart part.

The problem is demonstrated in the added tests.
