### PR TITLE
Fix Elixir 1.11 warnings by including :crypto as an application dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule Mail.Mixfile do
   #
   # Type "mix help compile.app" for more information
   def application do
-    [applications: [:logger]]
+    [applications: [:crypto, :logger]]
   end
 
   def package do


### PR DESCRIPTION
## Changes proposed in this pull request

Fixes the following warning in Elixir 1.11.

```
warning: :crypto.strong_rand_bytes/1 defined in application :crypto is used by the current application but the current application does not directly depend on :crypto. To fix this, you must do one of:

  1. If :crypto is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :crypto is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :crypto, you may optionally skip this warning by adding [xref: [exclude: :crypto] to your "def project" in mix.exs

  lib/mail/message.ex:174: Mail.Message.generate_boundary/0
```
