### PR TITLE
Default charset to UTF-8

### DIFF
--- a/lib/mail.ex
+++ b/lib/mail.ex
@@ -58,7 +58,7 @@ defmodule Mail do
           ["text/plain", {"charset", charset}]
 
         _else ->
-          "text/plain"
+          ["text/plain", {"charset", default_charset()}]
       end
 
     Mail.Message.put_body(message, body)
@@ -120,7 +120,7 @@ defmodule Mail do
           ["text/html", {"charset", charset}]
 
         _else ->
-          "text/html"
+          ["text/html", {"charset", default_charset()}]
       end
 
     Mail.Message.put_body(message, body)
@@ -149,6 +149,10 @@ defmodule Mail do
     do: message
 
   def get_html(%Mail.Message{}), do: nil
+
+  defp default_charset do
+    "UTF-8"
+  end
 
   @doc """
   Add an attachment part to the message

--- a/lib/mail/message.ex
+++ b/lib/mail/message.ex
@@ -203,7 +203,7 @@ defmodule Mail.Message do
           ["text/plain", {"charset", charset}]
 
         _else ->
-          "text/plain"
+          ["text/plain", {"charset", default_charset()}]
       end
 
     put_content_type(%Mail.Message{}, content_type)
@@ -231,12 +231,16 @@ defmodule Mail.Message do
           ["text/html", {"charset", charset}]
 
         _else ->
-          "text/html"
+          ["text/html", {"charset", default_charset()}]
       end
 
     put_content_type(%Mail.Message{}, content_type)
     |> put_header(:content_transfer_encoding, :quoted_printable)
     |> put_body(body)
+  end
+
+  defp default_charset do
+    "UTF-8"
   end
 
   @doc """

--- a/test/fixtures/multipart-jpeg-attachment-rendering.eml
+++ b/test/fixtures/multipart-jpeg-attachment-rendering.eml
@@ -8,13 +8,13 @@ Content-Type: multipart/mixed; boundary="2753118483D4F18DC5FD1F1A"
 Content-Type: multipart/alternative; boundary="DB28EC13A6576C8F20B92FD0"
 
 --DB28EC13A6576C8F20B92FD0
-Content-Type: text/plain
+Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: quoted-printable
 
 Some text
 
 --DB28EC13A6576C8F20B92FD0
-Content-Type: text/html
+Content-Type: text/html; charset=UTF-8
 Content-Transfer-Encoding: quoted-printable
 
 <h1>Some HTML</h1>

--- a/test/fixtures/recursive-part-rendering.eml
+++ b/test/fixtures/recursive-part-rendering.eml
@@ -1,13 +1,13 @@
 Content-Type: multipart/alternative; boundary="foobar"
 
 --foobar
-Content-Type: text/plain
+Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: quoted-printable
 
 Hello there! 1 + 1 =3D 2
 
 --foobar
-Content-Type: text/html
+Content-Type: text/html; charset=UTF-8
 Content-Transfer-Encoding: quoted-printable
 
 <a href=3D"/">Hello there! 1 + 1 =3D 2</a>

--- a/test/fixtures/simple-multipart-rendering.eml
+++ b/test/fixtures/simple-multipart-rendering.eml
@@ -6,13 +6,13 @@ Mime-Version: 1.0
 Content-Type: multipart/alternative; boundary="foobar"
 
 --foobar
-Content-Type: text/plain
+Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: quoted-printable
 
 Some text
 
 --foobar
-Content-Type: text/html
+Content-Type: text/html; charset=UTF-8
 Content-Transfer-Encoding: quoted-printable
 
 <h1>Some HTML</h1>

--- a/test/fixtures/simple-plain-rendering.eml
+++ b/test/fixtures/simple-plain-rendering.eml
@@ -1,6 +1,6 @@
 To: user@example.com
 Subject: Test email
-Content-Type: text/plain
+Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: quoted-printable
 
 Some text

--- a/test/mail/message_test.exs
+++ b/test/mail/message_test.exs
@@ -108,28 +108,28 @@ defmodule Mail.MessageTest do
 
   test "build_text" do
     message = Mail.Message.build_text("Some text")
-    assert Mail.Message.get_content_type(message) == ["text/plain"]
+    assert Mail.Message.get_content_type(message) == ["text/plain", {"charset", "UTF-8"}]
     assert Mail.Message.get_header(message, :content_transfer_encoding) == :quoted_printable
     assert message.body == "Some text"
   end
 
   test "build_text when given charset" do
-    message = Mail.Message.build_text("Some text", charset: "UTF-8")
-    assert Mail.Message.get_content_type(message) == ["text/plain", {"charset", "UTF-8"}]
+    message = Mail.Message.build_text("Some text", charset: "US-ASCII")
+    assert Mail.Message.get_content_type(message) == ["text/plain", {"charset", "US-ASCII"}]
     assert Mail.Message.get_header(message, :content_transfer_encoding) == :quoted_printable
     assert message.body == "Some text"
   end
 
   test "build_html" do
     message = Mail.Message.build_html("<h1>Some HTML</h1>")
-    assert Mail.Message.get_content_type(message) == ["text/html"]
+    assert Mail.Message.get_content_type(message) == ["text/html", {"charset", "UTF-8"}]
     assert Mail.Message.get_header(message, :content_transfer_encoding) == :quoted_printable
     assert message.body == "<h1>Some HTML</h1>"
   end
 
   test "build_html when given charset" do
-    message = Mail.Message.build_html("<h1>Some HTML</h1>", charset: "UTF-8")
-    assert Mail.Message.get_content_type(message) == ["text/html", {"charset", "UTF-8"}]
+    message = Mail.Message.build_html("<h1>Some HTML</h1>", charset: "US-ASCII")
+    assert Mail.Message.get_content_type(message) == ["text/html", {"charset", "US-ASCII"}]
     assert Mail.Message.get_header(message, :content_transfer_encoding) == :quoted_printable
     assert message.body == "<h1>Some HTML</h1>"
   end

--- a/test/mail_test.exs
+++ b/test/mail_test.exs
@@ -137,7 +137,7 @@ defmodule MailTest do
 
     assert length(mail.parts) == 0
     assert mail.body == "Some text"
-    assert Mail.Message.get_content_type(mail) == ["text/plain"]
+    assert Mail.Message.get_content_type(mail) == ["text/plain", {"charset", "UTF-8"}]
   end
 
   test "put_text with a multipart" do
@@ -147,7 +147,7 @@ defmodule MailTest do
     part = List.first(mail.parts)
 
     assert part.body == "Some text"
-    assert Mail.Message.get_content_type(part) == ["text/plain"]
+    assert Mail.Message.get_content_type(part) == ["text/plain", {"charset", "UTF-8"}]
   end
 
   test "put_text replaces existing text part in multipart" do
@@ -159,7 +159,7 @@ defmodule MailTest do
     part = List.first(mail.parts)
 
     assert part.body == "Some other text"
-    assert Mail.Message.get_content_type(part) == ["text/plain"]
+    assert Mail.Message.get_content_type(part) == ["text/plain", {"charset", "UTF-8"}]
   end
 
   test "get_text with singlepart" do
@@ -236,7 +236,7 @@ defmodule MailTest do
 
     assert length(mail.parts) == 0
     assert mail.body == "<h1>Some HTML</h1>"
-    assert Mail.Message.get_content_type(mail) == ["text/html"]
+    assert Mail.Message.get_content_type(mail) == ["text/html", {"charset", "UTF-8"}]
   end
 
   test "put_html with a multipart" do
@@ -246,7 +246,7 @@ defmodule MailTest do
     part = List.first(mail.parts)
 
     assert part.body == "<h1>Some HTML</h1>"
-    assert Mail.Message.get_content_type(part) == ["text/html"]
+    assert Mail.Message.get_content_type(part) == ["text/html", {"charset", "UTF-8"}]
   end
 
   test "put_html replaces existing html part in multipart" do
@@ -258,7 +258,7 @@ defmodule MailTest do
     part = List.first(mail.parts)
 
     assert part.body == "<h1>Some other html</h1>"
-    assert Mail.Message.get_content_type(part) == ["text/html"]
+    assert Mail.Message.get_content_type(part) == ["text/html", {"charset", "UTF-8"}]
   end
 
   test "get_html with singlepart" do


### PR DESCRIPTION
I would like to propose adding a default value for the content's charset. During our tests of emails sent out by our platform in different email clients, we noticed that different clients behave differently when the charset is completely missing, which meant unreadable emails in some of them. I think it would help everyone if there is a default set, and UTF-8 seems like the most popular option.

In our project, we use elixir-mail indirectly, via Bamboo and the adapter BambooSES. AFAIK, this doesn't offer us a clean way to set a charset on our own because the calls to `Mail.put_text`/`Mail.put_html` happen in those dependencies. 