### PR TITLE
Misc doc changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,26 @@
-/_build
-/cover
-/deps
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
 erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
 *.ez
-/doc
-.elixir_ls
+
+# Ignore package tarball (built via "mix hex.build").
+mail-*.tar
+
+# Temporary files for e.g. tests
+/tmp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-# Versions
+# Changelog
 
-## 0.2.2
+## 0.2.2 2020-07-28
 
 * Documentation updates
 * Handle parsing a recipient name which is an email address https://github.com/DockYard/elixir-mail/pull/123
@@ -19,13 +19,13 @@
 * Add support the Encoded Word RFC 2047 https://github.com/DockYard/elixir-mail/pull/90
 * Retail all "received" headers https://github.com/DockYard/elixir-mail/pull/89
 
-## 0.2.1
+## 0.2.1 2019-03-02
 
 * Fix quoted-printable encoding https://github.com/DockYard/elixir-mail/pull/83
 * Optimized quoted-printable encoder to reduce memory usage https://github.com/DockYard/elixir-mail/pull/87
 * Update RFC2822 email regex with a better one https://github.com/DockYard/elixir-mail/pull/86
 
-## 0.2.0
+## 0.2.0 2017-07-21
 
 * Breaking - All message props are now binaries https://github.com/DockYard/elixir-mail/pull/69
 * removed `Mail.Message.has_attachment?` and `Mail.Message.has_text_part?` https://github.com/DockYard/elixir-mail/pull/74
@@ -36,17 +36,17 @@
 * Support obsolete timestamps https://github.com/DockYard/elixir-mail/pull/70
 * Fix test suite for Elixir 1.4+ https://github.com/DockYard/elixir-mail/pull/67
 
-## 0.1.1
+## 0.1.1 2016-10-12
 
 * Moved API to using strings instead of atoms
 * Parser and Renderer should handle reply-to header
 
-## 0.1.0
+## 0.1.0 2016-07-31
 
 * API is stable enough for a minor version release
 * Resolved Elixir 1.3 warnings
 
-## 0.0.3
+## 0.0.3 2016-03-14
 
 * Began multipart support. The `Mail` struct can have multiple "parts".
   Each `Mail.Part` can have multiple "parts".

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -68,7 +68,7 @@ members of the project's leadership.
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at [http://contributor-covenant.org/version/1/4][version]
+available at [https://contributor-covenant.org/version/1/4][version]
 
-[homepage]: http://contributor-covenant.org
-[version]: http://contributor-covenant.org/version/1/4/
+[homepage]: https://contributor-covenant.org
+[version]: https://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ that reproduces the error condition.
 
 ## Have a feature request?
 
-Please provide some thoughful commentary and code samples on what this feature
+Please provide some thoughtful commentary and code samples on what this feature
 should do and why it should be added (your use case). The minimal questions you
 should answer when submitting a feature request should be:
 
@@ -51,10 +51,12 @@ First clone this repository:
 
 ```sh
 git clone https://github.com/DockYard/elixir-mail.git
+mix deps
+mix compile
 ```
-
-<!-- Add further details on how to install the project here -->
 
 ## Running tests
 
-<!-- Tell the user how to run the tests of your project -->
+```sh
+mix test
+```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Mail [![Build Status](https://secure.travis-ci.org/DockYard/elixir-mail.svg?branch=master)](http://travis-ci.org/DockYard/elixir-mail)
+# Mail [![Build Status](https://secure.travis-ci.org/DockYard/elixir-mail.svg?branch=master)](https://travis-ci.org/DockYard/elixir-mail)
 
 An RFC2822 implementation in Elixir, built for composability.
 
@@ -8,10 +8,13 @@ An RFC2822 implementation in Elixir, built for composability.
 
 ```elixir
 def deps do
-  # Get from hex
-  [{:mail, "~> 0.2"}]
-  # Or use the latest from master
-  [{:mail, github: "DockYard/elixir-mail"}]
+  [
+    # Get from hex
+    {:mail, "~> 0.2"},
+
+    # Or use the latest from master
+    {:mail, github: "DockYard/elixir-mail"}
+  ]
 end
 ```
 
@@ -33,7 +36,7 @@ message =
 #### Multi-Part
 
 ```elixir
-message = 
+message =
   Mail.build_multipart()
   |> Mail.put_text("Hello there!")
   |> Mail.put_html("<h1>Hello there!</h1>")
@@ -51,32 +54,32 @@ rendered_message = Mail.Renderers.RFC2822.render(message)
 
 ## Parsing
 
-If you'd like to parse an already rendered message back into 
+If you'd like to parse an already rendered message back into
 a data model:
 
 ```elixir
 Mail.Parsers.RFC2822.parse(rendered_message)
 ```
 
-[There are more functions described in the docs](http://hexdocs.pm/mail/Mail.html)
+[There are more functions described in the docs](https://hexdocs.pm/mail/Mail.html)
 
 ## Authors ##
 
-* [Brian Cardarella](http://twitter.com/bcardarella)
+* [Brian Cardarella](https://twitter.com/bcardarella)
 
 [We are very thankful for the many contributors](https://github.com/dockyard/elixir-mail/graphs/contributors)
 
 ## Versioning ##
 
-This library follows [Semantic Versioning](http://semver.org)
+This library follows [Semantic Versioning](https://semver.org)
 
 ## Looking for help with your Elixir project? ##
 
-[At DockYard we are ready to help you build your next Elixir project](https://dockyard.com/phoenix-consulting). We have a unique expertise 
+[At DockYard we are ready to help you build your next Elixir project](https://dockyard.com/phoenix-consulting). We have a unique expertise
 in Elixir and Phoenix development that is unmatched. [Get in touch!](https://dockyard.com/contact/hire-us)
 
 At DockYard we love Elixir! You can [read our Elixir blog posts](https://dockyard.com/blog/categories/elixir)
-or come visit us at [The Boston Elixir Meetup](http://www.meetup.com/Boston-Elixir/) that we organize.
+or come visit us at [The Boston Elixir Meetup](https://www.meetup.com/Boston-Elixir/) that we organize.
 
 ## Want to help? ##
 
@@ -86,8 +89,8 @@ on how to properly submit issues and pull requests.
 
 ## Legal ##
 
-[DockYard](http://dockyard.com/), Inc. &copy; 2015
+[DockYard](https://dockyard.com/), Inc. © 2015
 
-[@dockyard](http://twitter.com/dockyard)
+[@dockyard](https://twitter.com/dockyard)
 
-[Licensed under the MIT license](http://www.opensource.org/licenses/mit-license.php)
+[Licensed under the MIT license](https://www.opensource.org/licenses/mit-license.php)

--- a/lib/mail/encoders/base64.ex
+++ b/lib/mail/encoders/base64.ex
@@ -6,8 +6,8 @@ defmodule Mail.Encoders.Base64 do
 
   See the following links for reference:
   - <https://www.ietf.org/rfc/rfc2045.txt>
-  - <http://stackoverflow.com/questions/25710599/content-transfer-encoding-7bit-or-8-bit>
-  - <http://stackoverflow.com/questions/13301708/base64-encode-length-parameter>
+  - <https://stackoverflow.com/questions/25710599/content-transfer-encoding-7bit-or-8-bit>
+  - <https://stackoverflow.com/questions/13301708/base64-encode-length-parameter>
   """
 
   def encode(string),

--- a/lib/mail/message.ex
+++ b/lib/mail/message.ex
@@ -113,7 +113,7 @@ defmodule Mail.Message do
   @doc """
   Gets the `content_type` from the header
 
-  Will ensure the `content_type` is always wraped in a `List`
+  Will ensure the `content_type` is always wrapped in a `List`
 
       Mail.Message.get_content_type(%Mail.Message{})
       [""]
@@ -287,7 +287,7 @@ defmodule Mail.Message do
   @doc """
   Adds a new attachment part to the provided message
 
-  The first argument must be a `Mail.Message`. The remaining argument is descibed in `build_attachment/1`
+  The first argument must be a `Mail.Message`. The remaining argument is described in `build_attachment/1`
 
   ## Options
     * `:headers` - Headers to be merged

--- a/lib/mail/proplist.ex
+++ b/lib/mail/proplist.ex
@@ -1,8 +1,8 @@
 defmodule Mail.Proplist do
   @moduledoc """
-  A hybrid of erlang's proplists and lists keystores.
+  A hybrid of Erlang's proplists and lists keystores.
 
-  It acts as a Set for key-value pairs, but stil maintains it's order like a
+  It acts as a Set for key-value pairs, but still maintains it's order like a
   List.
   """
 
@@ -116,7 +116,7 @@ defmodule Mail.Proplist do
   end
 
   @doc """
-  Concatentates the given lists.
+  Concatenates the given lists.
 
   Args:
   * `a` - base list to merge unto

--- a/mix.exs
+++ b/mix.exs
@@ -1,24 +1,24 @@
 defmodule Mail.Mixfile do
   use Mix.Project
 
+  @source_url "https://github.com/DockYard/elixir-mail"
+  @version "0.2.2"
+
   def project do
     [
       app: :mail,
-      version: "0.2.2",
-      elixir: "~> 1.2",
+      version: @version,
+      elixir: "~> 1.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       description: description(),
       package: package(),
-      docs: [main: "Mail"],
+      docs: docs(),
       deps: deps()
     ]
   end
 
-  # Configuration for the OTP application
-  #
-  # Type "mix help compile.app" for more information
   def application do
     [applications: [:crypto, :logger]]
   end
@@ -28,10 +28,19 @@ defmodule Mail.Mixfile do
       maintainers: ["Brian Cardarella", "Andrew Timberlake"],
       licenses: ["MIT"],
       links: %{
-        "GitHub" => "https://github.com/DockYard/elixir-mail",
+        "GitHub" => @source_url,
         "Built by DockYard, Expert Elixir & Phoenix Consultants" =>
           "https://dockyard.com/phoenix-consulting"
       }
+    ]
+  end
+
+  defp docs do
+    [
+      extras: ["CHANGELOG.md", "README.md"],
+      main: "readme",
+      source_url: @source_url,
+      source_ref: "v#{@version}"
     ]
   end
 
@@ -42,19 +51,9 @@ defmodule Mail.Mixfile do
   defp elixirc_paths(:test), do: ["lib", "test/support"]
   defp elixirc_paths(_), do: ["lib"]
 
-  # Dependencies can be Hex packages:
-  #
-  #   {:mydep, "~> 0.3.0"}
-  #
-  # Or git/path repositories:
-  #
-  #   {:mydep, git: "https://github.com/elixir-lang/mydep.git", tag: "0.1.0"}
-  #
-  # Type "mix help deps" for more examples and options
   defp deps do
     [
-      {:earmark, "~> 1.3", only: :dev},
-      {:ex_doc, "~> 0.19", only: :dev}
+      {:ex_doc, ">= 0.0.0", only: :dev, runtime: false}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,10 +1,10 @@
 %{
   "earmark": {:hex, :earmark, "1.4.10", "bddce5e8ea37712a5bfb01541be8ba57d3b171d3fa4f80a0be9bcf1db417bcaf", [:mix], [{:earmark_parser, ">= 1.4.10", [hex: :earmark_parser, repo: "hexpm", optional: false]}], "hexpm", "12dbfa80810478e521d3ffb941ad9fbfcbbd7debe94e1341b4c4a1b2411c1c27"},
-  "earmark_parser": {:hex, :earmark_parser, "1.4.10", "6603d7a603b9c18d3d20db69921527f82ef09990885ed7525003c7fe7dc86c56", [:mix], [], "hexpm", "8e2d5370b732385db2c9b22215c3f59c84ac7dda7ed7e544d7c459496ae519c0"},
-  "ex_doc": {:hex, :ex_doc, "0.22.2", "03a2a58bdd2ba0d83d004507c4ee113b9c521956938298eba16e55cc4aba4a6c", [:mix], [{:earmark_parser, "~> 1.4.0", [hex: :earmark_parser, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm", "cf60e1b3e2efe317095b6bb79651f83a2c1b3edcb4d319c421d7fcda8b3aff26"},
-  "makeup": {:hex, :makeup, "1.0.3", "e339e2f766d12e7260e6672dd4047405963c5ec99661abdc432e6ec67d29ef95", [:mix], [{:nimble_parsec, "~> 0.5", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "2e9b4996d11832947731f7608fed7ad2f9443011b3b479ae288011265cdd3dad"},
-  "makeup_elixir": {:hex, :makeup_elixir, "0.14.1", "4f0e96847c63c17841d42c08107405a005a2680eb9c7ccadfd757bd31dabccfb", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "f2438b1a80eaec9ede832b5c41cd4f373b38fd7aa33e3b22d9db79e640cbde11"},
+  "earmark_parser": {:hex, :earmark_parser, "1.4.12", "b245e875ec0a311a342320da0551da407d9d2b65d98f7a9597ae078615af3449", [:mix], [], "hexpm", "711e2cc4d64abb7d566d43f54b78f7dc129308a63bc103fbd88550d2174b3160"},
+  "ex_doc": {:hex, :ex_doc, "0.23.0", "a069bc9b0bf8efe323ecde8c0d62afc13d308b1fa3d228b65bca5cf8703a529d", [:mix], [{:earmark_parser, "~> 1.4.0", [hex: :earmark_parser, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm", "f5e2c4702468b2fd11b10d39416ddadd2fcdd173ba2a0285ebd92c39827a5a16"},
+  "makeup": {:hex, :makeup, "1.0.5", "d5a830bc42c9800ce07dd97fa94669dfb93d3bf5fcf6ea7a0c67b2e0e4a7f26c", [:mix], [{:nimble_parsec, "~> 0.5 or ~> 1.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "cfa158c02d3f5c0c665d0af11512fed3fba0144cf1aadee0f2ce17747fba2ca9"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.15.1", "b5888c880d17d1cc3e598f05cdb5b5a91b7b17ac4eaf5f297cb697663a1094dd", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.1", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "db68c173234b07ab2a07f645a5acdc117b9f99d69ebf521821d89690ae6c6ec8"},
   "mimerl": {:hex, :mimerl, "1.1.0"},
-  "nimble_parsec": {:hex, :nimble_parsec, "0.6.0", "32111b3bf39137144abd7ba1cce0914533b2d16ef35e8abc5ec8be6122944263", [:mix], [], "hexpm", "27eac315a94909d4dc68bc07a4a83e06c8379237c5ea528a9acff4ca1c873c52"},
+  "nimble_parsec": {:hex, :nimble_parsec, "1.1.0", "3a6fca1550363552e54c216debb6a9e95bd8d32348938e13de5eda962c0d7f89", [:mix], [], "hexpm", "08eb32d66b706e913ff748f11694b17981c0b04a33ef470e33e11b3d3ac8f54b"},
   "plug": {:hex, :plug, "1.1.0"},
 }


### PR DESCRIPTION
Besides other fixes, this commit allows the generated HTML doc for
HexDocs.pm will become the main doc source for this Elixir module.
Leverage on features provided by ExDoc, we can search through Readme,
Changelog, and API. We can also jump to the actual Elixir source from
the function definitions.

List of changes:
* http -> https
* Tally mininum Elixir version with Travis CI
* Use and set ex_doc to latest version
* Update gitignore
* Fix typos
* Add release date to Changelog
* Set readme as main HTML doc
* Add changelog to HTML doc
* Update installation example
* Add missing contributing notes

<!--
Thank you for contributing!

Here are a few things that will increase the chance that your pull request will get accepted:
 - Write tests, preferably in a test driven style.
 - Add documentation for the changes you made.
 - Follow our styleguide: https://github.com/dockyard/styleguides
-->

<!-- If this pull request addresses an issue please provide the issue number here -->
Closes # .

## Changes proposed in this pull request
<!-- Please describe here what this pull request changes -->
