### PR TITLE
Handle uppercase month name in date

### DIFF
--- a/lib/mail/parsers/rfc_2822.ex
+++ b/lib/mail/parsers/rfc_2822.ex
@@ -9,7 +9,7 @@ defmodule Mail.Parsers.RFC2822 do
       %Mail.Message{body: "Some message", headers: %{to: ["user@example.com"], from: "other@example.com", subject: "Read this!"}}
   """
 
-  @months ~w(Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec)
+  @months ~w(jan feb mar apr may jun jul aug sep oct nov dec)
 
   @spec parse(binary() | nonempty_maybe_improper_list()) :: Mail.Message.t()
   def parse(content)
@@ -84,7 +84,8 @@ defmodule Mail.Parsers.RFC2822 do
           _timezone::binary-size(5), _rest::binary>>
       ) do
     year = year |> String.to_integer()
-    month = Enum.find_index(@months, &(&1 == month)) + 1
+    month_name = String.downcase(month)
+    month = Enum.find_index(@months, &(&1 == month_name)) + 1
     date = date |> String.to_integer()
 
     hour = hour |> String.to_integer()

--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -138,6 +138,7 @@ defmodule Mail.Parsers.RFC2822Test do
     assert erl_from_timestamp("03 Apr 2017 12:30:55 GMT") == {{2017, 4, 3}, {12, 30, 55}}
     # The spec specifies that the seconds are optional
     assert erl_from_timestamp("14 Jun 2019 11:24 +0000") == {{2019, 6, 14}, {11, 24, 0}}
+    assert erl_from_timestamp("28 JUN 2021 09:10 +0200") == {{2021, 6, 28}, {9, 10, 0}}
   end
 
   test "erl_from_timestamp\1 with invalid RFC2822 timestamps (found in the wild)" do


### PR DESCRIPTION
I’ve had some parsing issues with uppercase month names in the date string.
This test is from a date found in the wild.