### PR TITLE
Keep original order of text parts

### DIFF
--- a/lib/mail/renderers/rfc_2822.ex
+++ b/lib/mail/renderers/rfc_2822.ex
@@ -255,10 +255,7 @@ defmodule Mail.Renderers.RFC2822 do
     content_type = Mail.Message.get_content_type(message)
 
     if Mail.Message.has_attachment?(message) do
-      text_parts =
-        Enum.filter(message.parts, &match_content_type?(&1, ~r/text\/(plain|html)/))
-        |> Enum.sort(&(&1 > &2))
-
+      text_parts = Enum.filter(message.parts, &match_content_type?(&1, ~r/text\/(plain|html)/))
       content_type = List.replace_at(content_type, 0, "multipart/mixed")
       message = Mail.Message.put_content_type(message, content_type)
 

--- a/lib/mail/renderers/rfc_2822.ex
+++ b/lib/mail/renderers/rfc_2822.ex
@@ -1,5 +1,5 @@
 defmodule Mail.Renderers.RFC2822 do
-  import Mail.Message, only: [match_content_type?: 2]
+  import Mail.Message, only: [match_content_type?: 2, is_attachment?: 1]
 
   @days ~w(Mon Tue Wed Thu Fri Sat Sun)
   @months ~w(Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec)
@@ -255,7 +255,12 @@ defmodule Mail.Renderers.RFC2822 do
     content_type = Mail.Message.get_content_type(message)
 
     if Mail.Message.has_attachment?(message) do
-      text_parts = Enum.filter(message.parts, &match_content_type?(&1, ~r/text\/(plain|html)/))
+      text_parts =
+        Enum.filter(
+          message.parts,
+          &(match_content_type?(&1, ~r/text\/(plain|html)/) and not is_attachment?(&1))
+        )
+
       content_type = List.replace_at(content_type, 0, "multipart/mixed")
       message = Mail.Message.put_content_type(message, content_type)
 


### PR DESCRIPTION
This removes the sorting of the message parts when rendering the email with the RFC2822 renderer. 

I've tested the generated email in the Apple email client, and it seems like it'll use always choose the last text part for displaying. Therefore, I'd prefer if the original order of the text parts was preserved.

Feel free to close this issue if the sorting is necessary for other purposes