### PR TITLE
Split encoded words on headers

### DIFF
--- a/lib/mail/encoders/quoted_printable.ex
+++ b/lib/mail/encoders/quoted_printable.ex
@@ -28,8 +28,8 @@ defmodule Mail.Encoders.QuotedPrintable do
   end
 
   # Encode ASCII characters in range 0x20..0x3C.
-  # Encode ASCII characters in range 0x3E..0x7E.
-  def encode(<<char, tail::binary>>, acc, line_length) when char in ?!..?< or char in ?>..?~ do
+  # Encode ASCII characters in range 0x3E..0x7E, except 0x3F (question mark)
+  def encode(<<char, tail::binary>>, acc, line_length) when char in ?!..?< or char in ?@..?~ or char == ?> do
     if line_length < @max_length - 1 do
       encode(tail, [<<char>> | acc], line_length + 1)
     else

--- a/lib/mail/encoders/quoted_printable.ex
+++ b/lib/mail/encoders/quoted_printable.ex
@@ -18,10 +18,10 @@ defmodule Mail.Encoders.QuotedPrintable do
       "fa=C3=A7ade"
   """
   @spec encode(binary) :: binary
-  @spec encode(binary, list, non_neg_integer) :: binary
-  def encode(string, acc \\ [], line_length \\ 0)
+  @spec encode(binary, integer, list, non_neg_integer) :: binary
+  def encode(string, max_length \\ @max_length, acc \\ [], line_length \\ 0)
 
-  def encode(<<>>, acc, _) do
+  def encode(<<>>, _, acc, _) do
     acc
     |> Enum.reverse()
     |> Enum.join()
@@ -29,44 +29,44 @@ defmodule Mail.Encoders.QuotedPrintable do
 
   # Encode ASCII characters in range 0x20..0x3C.
   # Encode ASCII characters in range 0x3E..0x7E, except 0x3F (question mark)
-  def encode(<<char, tail::binary>>, acc, line_length) when char in ?!..?< or char in ?@..?~ or char == ?> do
-    if line_length < @max_length - 1 do
-      encode(tail, [<<char>> | acc], line_length + 1)
+  def encode(<<char, tail::binary>>, max_length, acc, line_length) when char in ?!..?< or char in ?@..?~ or char == ?> do
+    if line_length < max_length - 1 do
+      encode(tail, max_length, [<<char>> | acc], line_length + 1)
     else
-      encode(tail, [<<char>>, @new_line | acc], 1)
+      encode(tail, max_length, [<<char>>, @new_line | acc], 1)
     end
   end
 
   # Encode ASCII tab and space characters.
-  def encode(<<char, tail::binary>>, acc, line_length) when char in [?\t, ?\s] do
+  def encode(<<char, tail::binary>>, max_length, acc, line_length) when char in [?\t, ?\s] do
     # if remaining > 0 do
     if byte_size(tail) > 0 do
-      if line_length < @max_length - 1 do
-        encode(tail, [<<char>> | acc], line_length + 1)
+      if line_length < max_length - 1 do
+        encode(tail, max_length, [<<char>> | acc], line_length + 1)
       else
-        encode(tail, [<<char>>, @new_line | acc], 1)
+        encode(tail, max_length, [<<char>>, @new_line | acc], 1)
       end
     else
       escaped = "=" <> Base.encode16(<<char>>)
       line_length = line_length + byte_size(escaped)
 
-      if line_length <= @max_length do
-        encode(tail, [escaped | acc], line_length)
+      if line_length <= max_length do
+        encode(tail, max_length, [escaped | acc], line_length)
       else
-        encode(tail, [escaped, @new_line | acc], byte_size(escaped))
+        encode(tail, max_length, [escaped, @new_line | acc], byte_size(escaped))
       end
     end
   end
 
   # Encode all other characters.
-  def encode(<<char, tail::binary>>, acc, line_length) do
+  def encode(<<char, tail::binary>>, max_length, acc, line_length) do
     escaped = "=" <> Base.encode16(<<char>>)
     line_length = line_length + byte_size(escaped)
 
-    if line_length < @max_length do
-      encode(tail, [escaped | acc], line_length)
+    if line_length < max_length do
+      encode(tail, max_length, [escaped | acc], line_length)
     else
-      encode(tail, [escaped, @new_line | acc], byte_size(escaped))
+      encode(tail, max_length, [escaped, @new_line | acc], byte_size(escaped))
     end
   end
 

--- a/test/mail/encoders/quoted_printable_test.exs
+++ b/test/mail/encoders/quoted_printable_test.exs
@@ -12,8 +12,12 @@ defmodule Mail.Encoders.QuotedPrintableTest do
     ascii_upper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
     assert Mail.Encoders.QuotedPrintable.encode(ascii_upper) == ascii_upper
 
-    ascii_symbols = "!\"#$%&\'()*+,-./0123456789:;<>?@[\\]^_`{|}~"
+    ascii_symbols = "!\"#$%&\'()*+,-./0123456789:;<>@[\\]^_`{|}~"
     assert Mail.Encoders.QuotedPrintable.encode(ascii_symbols) == ascii_symbols
+  end
+
+  test "encodes question mark sign" do
+    assert Mail.Encoders.QuotedPrintable.encode("hello?goodbye") == "hello=3Fgoodbye"
   end
 
   test "encodes equal sign" do

--- a/test/mail/message_test.exs
+++ b/test/mail/message_test.exs
@@ -247,4 +247,18 @@ defmodule Mail.MessageTest do
              headers: %{"content-disposition" => ["attachment", {"filename", ^file_name}]}
            } = Mail.Parsers.RFC2822.parse(message)
   end
+
+  test "long UTF-8 in subject" do
+    subject = "über alles\nnew ?= line some очень-очень-очень-очень-очень-очень-очень-очень-очень-очень-очень-очень long line"
+
+    txt =
+      Mail.build()
+      |> Mail.put_subject(subject)
+      |> Mail.render()
+
+    encoded_subject = "=?UTF-8?Q?=C3=BCber alles=0Anew =3F=3D line some =D0=BE=D1=87=D0=B5=D0=BD?==?UTF-8?Q?=D1=8C-=D0=BE=D1=87=D0=B5=D0=BD=D1=8C-=D0=BE=D1=87=D0=B5=D0=BD?==?UTF-8?Q?=D1=8C-=D0=BE=D1=87=D0=B5=D0=BD=D1=8C-=D0=BE=D1=87=D0=B5=D0=BD?==?UTF-8?Q?=D1=8C-=D0=BE=D1=87=D0=B5=D0=BD=D1=8C-=D0=BE=D1=87=D0=B5=D0=BD?==?UTF-8?Q?=D1=8C-=D0=BE=D1=87=D0=B5=D0=BD=D1=8C-=D0=BE=D1=87=D0=B5=D0=BD?==?UTF-8?Q?=D1=8C-=D0=BE=D1=87=D0=B5=D0=BD=D1=8C-=D0=BE=D1=87=D0=B5=D0=BD?==?UTF-8?Q?=D1=8C-=D0=BE=D1=87=D0=B5=D0=BD=D1=8C long line?="
+
+    assert String.contains?(txt, encoded_subject)
+    assert %Mail.Message{headers: %{"subject" => ^subject}} = Mail.Parsers.RFC2822.parse(txt)
+  end
 end


### PR DESCRIPTION
## Changes proposed in this pull request

On version 0.2.3, escaping headers were introduced exactly by this [PR-131](https://github.com/DockYard/elixir-mail/pull/131/files)

Unfortunately this change ignored [RFC-2047 Section 2](https://datatracker.ietf.org/doc/html/rfc2047#section-2) regarding encoded words having a maximum size of 76 characters including prefix `=?UTF-8?Q?` and suffix `?=`.

One other thing this PR fixes is regarding question mark was not being escaped.

At [RFC-2045 Section 6.7](https://datatracker.ietf.org/doc/html/rfc2045#section-6.7) is listed on rule 2 that question marks (among other characters) could be encoded (but not mandatory) and we don't encode it. But encoding it would simplify the way we handle encoded words prefixes and suffixes as I describe below.

Take `sufixo ?= incluído aqui` as an example.

Not encoding question mark, we have: `=?UTF-8?Q?sufixo ?=3D inclu=C3=ADdo aqui?=` that decoded translates to `sufixo 3D inclu=C3=ADdo aqui ?=`.

If we encode question mark we have `=?UTF-8?Q?sufixo =3F=3D inclu=C3=ADdo aqui?=` and then we don't have any issue.

