### PR TITLE
fix type for dialyzer

### DIFF
--- a/lib/mail/message.ex
+++ b/lib/mail/message.ex
@@ -4,7 +4,7 @@ defmodule Mail.Message do
             parts: [],
             multipart: false
 
-  @type t :: __MODULE__
+  @type t :: %__MODULE__{}
 
   @doc """
   Add new part


### PR DESCRIPTION
We were running Dialyzer on our project and ran into some issues with this type definition being for the module rather than the struct. Once we made this change, Dialyzer stopped complaining about the types not matching.

Dialyzer output this resolves:
```
lib/mail/parsers/rfc_2822.ex:19:invalid_contract
The @spec for the function does not match the success typing of the function.

Function:
Mail.Parsers.RFC2822.parse/1

Success typing:
@spec parse(binary() | nonempty_maybe_improper_list()) :: %Mail.Message{
  :body => nil | binary(),
  :headers => map(),
  :multipart => boolean(),
  :parts => [any()]
}
```

<!--
Thank you for contributing!

Here are a few things that will increase the chance that your pull request will get accepted:
 - Write tests, preferably in a test driven style.
 - Add documentation for the changes you made.
 - Follow our styleguide: https://github.com/dockyard/styleguides
-->

<!-- If this pull request addresses an issue please provide the issue number here -->
Closes # .

## Changes proposed in this pull request
<!-- Please describe here what this pull request changes -->
