### PR TITLE
Handle unexpected encoded value

### DIFF
--- a/lib/mail.ex
+++ b/lib/mail.ex
@@ -212,8 +212,16 @@ defmodule Mail do
     walk_parts([message], {:cont, []}, fn message, acc ->
       case Mail.Message.is_attachment?(message) do
         true ->
-          ["attachment", {"filename", filename} | _] =
-            Mail.Message.get_header(message, :content_disposition)
+          case Mail.Message.get_header(message, :content_disposition) do
+            ["attachment", {"filename", filename} | _] ->
+              {:cont, List.insert_at(acc, -1, {filename, message.body})}
+
+            "attachment" ->
+              ["application/pdf", {"name", filename} | _] =
+                Mail.Message.get_header(message, "content-type")
+
+              {:cont, List.insert_at(acc, -1, {filename, message.body})}
+          end
 
           {:cont, List.insert_at(acc, -1, {filename, message.body})}
 

--- a/lib/mail/parsers/rfc_2822.ex
+++ b/lib/mail/parsers/rfc_2822.ex
@@ -275,9 +275,8 @@ defmodule Mail.Parsers.RFC2822 do
     decoded_string <> parse_encoded_word(remainder)
   end
 
-  defp parse_encoded_word(<<char::utf8, rest::binary>>) do
-    <<char::utf8, parse_encoded_word(rest)::binary>>
-  end
+  defp parse_encoded_word(<<char::utf8, rest::binary>>),
+    do: <<char::utf8, parse_encoded_word(rest)::binary>>
 
   defp parse_structured_header_value(string, value \\ nil, sub_types \\ [], acc \\ "")
 

--- a/lib/mail/parsers/rfc_2822.ex
+++ b/lib/mail/parsers/rfc_2822.ex
@@ -270,8 +270,9 @@ defmodule Mail.Parsers.RFC2822 do
           end
 
         decoded_string <> parse_encoded_word(remainder)
-    else
-      value
+
+      _ ->
+        value
     end
   end
 

--- a/lib/mail/parsers/rfc_2822.ex
+++ b/lib/mail/parsers/rfc_2822.ex
@@ -258,19 +258,21 @@ defmodule Mail.Parsers.RFC2822 do
   defp parse_encoded_word(""), do: ""
 
   defp parse_encoded_word(<<"=?", value::binary>>) do
-    [_charset, encoding, encoded_string, <<"=", remainder::binary>>] =
-      String.split(value, "?", parts: 4)
+    case String.split(value, "?", parts: 4) do
+      [_charset, encoding, encoded_string, <<"=", remainder::binary>>] ->
+        decoded_string =
+          case String.upcase(encoding) do
+            "Q" ->
+              Mail.Encoders.QuotedPrintable.decode(encoded_string)
 
-    decoded_string =
-      case String.upcase(encoding) do
-        "Q" ->
-          Mail.Encoders.QuotedPrintable.decode(encoded_string)
+            "B" ->
+              Mail.Encoders.Base64.decode(encoded_string)
+          end
 
-        "B" ->
-          Mail.Encoders.Base64.decode(encoded_string)
-      end
-
-    decoded_string <> parse_encoded_word(remainder)
+        decoded_string <> parse_encoded_word(remainder)
+    else
+      value
+    end
   end
 
   defp parse_encoded_word(<<char::utf8, rest::binary>>),

--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -430,6 +430,33 @@ defmodule Mail.Parsers.RFC2822Test do
              part.headers["content-disposition"]
   end
 
+  # See https://tools.ietf.org/html/rfc2047
+  test "handles URLs as values and not parseable encoded words" do
+    message =
+      parse_email("""
+      To: user@example.com
+      From: me@example.com
+      Subject: =?utf-8?Q?=C2=A3?=200.00 =?UTF-8?q?=F0=9F=92=B5?=
+      List-Unsubscribe: https://some-domain.com/te/c/abcdef=?signature=abcdef
+      Content-Type: multipart/mixed;
+      	boundary="----=_Part_295474_20544590.1456382229928"
+
+      ------=_Part_295474_20544590.1456382229928
+      Content-Type: text/plain
+
+      This is some text
+
+      ------=_Part_295474_20544590.1456382229928
+      Content-Type: image/png
+      Content-Disposition: attachment; filename=Emoji =?utf-8?B?8J+YgA==?= Filename.png
+
+      iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==
+      ------=_Part_295474_20544590.1456382229928--
+      """)
+
+    assert message.headers["list-unsubscribe"] == "https://some-domain.com/te/c/abcdef=?signature=abcdef"
+  end
+
   test "parses structured header with extraneous semicolon" do
     message =
       parse_email("""


### PR DESCRIPTION
## Changes proposed in this pull request
A header in one of the emails which contains a URL is breaking a specific function.

Error message:
```
** (MatchError) no match of right hand side value: ["signature=374a478e0350ddefa92d80b63f8763c85b289539eee166b47ceca61bfd3397ec"]
    (mail 0.2.3) lib/mail/parsers/rfc_2822.ex:261: Mail.Parsers.RFC2822.parse_encoded_word/1
    (mail 0.2.3) lib/mail/parsers/rfc_2822.ex:277: Mail.Parsers.RFC2822.parse_encoded_word/1
    (mail 0.2.3) lib/mail/parsers/rfc_2822.ex:199: Mail.Parsers.RFC2822.parse_headers/2
    (mail 0.2.3) lib/mail/parsers/rfc_2822.ex:21: Mail.Parsers.RFC2822.parse/1
```

The header in question is a URL like this, which isn't matching the expected return value of the `String.split` in that function:
```
List-Unsubscribe: https://some-domain.com/te/c/abcdef=?signature=abcdef
```

Would just like to have this parser ignore URL values.