### PR TITLE
Handle strings that appear to be quoted printable but are not (#141)

### DIFF
--- a/lib/mail/parsers/rfc_2822.ex
+++ b/lib/mail/parsers/rfc_2822.ex
@@ -258,19 +258,23 @@ defmodule Mail.Parsers.RFC2822 do
   defp parse_encoded_word(""), do: ""
 
   defp parse_encoded_word(<<"=?", value::binary>>) do
-    [_charset, encoding, encoded_string, <<"=", remainder::binary>>] =
-      String.split(value, "?", parts: 4)
+    case String.split(value, "?", parts: 4) do
+      [_charset, encoding, encoded_string, <<"=", remainder::binary>>] ->
+        decoded_string =
+          case String.upcase(encoding) do
+            "Q" ->
+              Mail.Encoders.QuotedPrintable.decode(encoded_string)
 
-    decoded_string =
-      case String.upcase(encoding) do
-        "Q" ->
-          Mail.Encoders.QuotedPrintable.decode(encoded_string)
+            "B" ->
+              Mail.Encoders.Base64.decode(encoded_string)
+          end
 
-        "B" ->
-          Mail.Encoders.Base64.decode(encoded_string)
-      end
+        decoded_string <> parse_encoded_word(remainder)
 
-    decoded_string <> parse_encoded_word(remainder)
+      _ ->
+        # Not an encoded word, moving on
+        "=?" <> parse_encoded_word(value)
+    end
   end
 
   defp parse_encoded_word(<<char::utf8, rest::binary>>),

--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -430,6 +430,30 @@ defmodule Mail.Parsers.RFC2822Test do
              part.headers["content-disposition"]
   end
 
+  test "parses headers with non-encoded string that looks like encoded word syntax" do
+    message =
+      parse_email("""
+      To: user@example.com
+      From: me@example.com
+      Subject: Subject that has =? for an unknown reason with =?utf-8?B?8J+YgA==?=
+      List-Unsubscribe: https://some-domain.com/te/c/abcdef=?signature=abcdef
+      Content-Type: multipart/mixed;
+      	boundary="----=_Part_295474_20544590.1456382229928"
+
+      ------=_Part_295474_20544590.1456382229928
+      Content-Type: text/plain
+
+      This is some text
+
+      ------=_Part_295474_20544590.1456382229928--
+      """)
+
+    assert message.headers["subject"] == "Subject that has =? for an unknown reason with 😀"
+
+    assert message.headers["list-unsubscribe"] ==
+             "https://some-domain.com/te/c/abcdef=?signature=abcdef"
+  end
+
   test "parses structured header with extraneous semicolon" do
     message =
       parse_email("""


### PR DESCRIPTION
This is a more generic fix for #141 