### PR TITLE
Implicit charset of us-ascii

### DIFF
--- a/lib/mail/parsers/rfc_2822.ex
+++ b/lib/mail/parsers/rfc_2822.ex
@@ -245,8 +245,12 @@ defmodule Mail.Parsers.RFC2822 do
   defp parse_header_value("Received", value),
     do: parse_received_value(value)
 
-  defp parse_header_value("Content-Type", value),
-    do: parse_structured_header_value(value)
+  defp parse_header_value("Content-Type", value) do
+    case parse_structured_header_value(value) do
+      [_ | _] = header -> header
+      <<value::binary>> -> [value, {"charset", "us-ascii"}]
+    end
+  end
 
   defp parse_header_value("Content-Disposition", value),
     do: parse_structured_header_value(value)

--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -78,10 +78,10 @@ defmodule Mail.Parsers.RFC2822Test do
 
     [text_part, html_part] = message.parts
 
-    assert text_part.headers["content-type"] == "text/plain"
+    assert text_part.headers["content-type"] == ["text/plain", {"charset", "us-ascii"}]
     assert text_part.body == "This is some text"
 
-    assert html_part.headers["content-type"] == "text/html"
+    assert html_part.headers["content-type"] == ["text/html", {"charset", "us-ascii"}]
     assert html_part.body == "<h1>This is some HTML</h1>"
   end
 
@@ -116,10 +116,10 @@ defmodule Mail.Parsers.RFC2822Test do
 
     [text_part, html_part, headers_only_part] = message.parts
 
-    assert text_part.headers["content-type"] == "text/plain"
+    assert text_part.headers["content-type"] == ["text/plain", {"charset", "us-ascii"}]
     assert text_part.body == "This is some text"
 
-    assert html_part.headers["content-type"] == "text/html"
+    assert html_part.headers["content-type"] == ["text/html", {"charset", "us-ascii"}]
     assert html_part.body == "<h1>This is some HTML</h1>"
 
     assert headers_only_part.headers["x-my-header"] == "no body!"
@@ -224,13 +224,13 @@ defmodule Mail.Parsers.RFC2822Test do
     assert alt_part.headers["content-type"] == ["multipart/alternative", {"boundary", "bazqux"}]
     [text_part, html_part] = alt_part.parts
 
-    assert text_part.headers["content-type"] == "text/plain"
+    assert text_part.headers["content-type"] == ["text/plain", {"charset", "us-ascii"}]
     assert text_part.body == "This is some text"
 
-    assert html_part.headers["content-type"] == "text/html"
+    assert html_part.headers["content-type"] == ["text/html", {"charset", "us-ascii"}]
     assert html_part.body == "<h1>This is the HTML</h1>"
 
-    assert attach_part.headers["content-type"] == "text/markdown"
+    assert attach_part.headers["content-type"] == ["text/markdown", {"charset", "us-ascii"}]
     assert attach_part.headers["content-disposition"] == ["attachment", {"filename", "README.md"}]
     assert attach_part.headers["content-transfer-encoding"] == "base64"
     assert attach_part.body == "Hello world!"
@@ -611,10 +611,19 @@ defmodule Mail.Parsers.RFC2822Test do
     assert message.body == nil
   end
 
-  test "content-type with implicit charset" do
+  test "content-type with explicit charset" do
     message =
       parse_email("""
       Content-Type: text/html; charset=us-ascii
+      """)
+
+    assert message.headers["content-type"] == ["text/html", {"charset", "us-ascii"}]
+  end
+
+  test "content-type with implicit charset" do
+    message =
+      parse_email("""
+      Content-Type: text/html
       """)
 
     assert message.headers["content-type"] == ["text/html", {"charset", "us-ascii"}]


### PR DESCRIPTION
#117 makes a point about an implicit charset
[RFC 2045 §5.2](https://datatracker.ietf.org/doc/html/rfc2045#section-5.2) states that when no charset is specified, us-ascii should be assumed as default.
This change adds the us-ascii charset when no charset is specified but may be a breaking change as seen in the number of test cases that needed to be updated to accommodate this change. 