### PR TITLE
Use a binary accumulator in QuotedPrintable encoder to reduce memory usage

### DIFF
--- a/lib/mail/encoders/quoted_printable.ex
+++ b/lib/mail/encoders/quoted_printable.ex
@@ -19,21 +19,18 @@ defmodule Mail.Encoders.QuotedPrintable do
   """
   @spec encode(binary) :: binary
   @spec encode(binary, integer, list, non_neg_integer) :: binary
-  def encode(string, max_length \\ @max_length, acc \\ [], line_length \\ 0)
+  def encode(string, max_length \\ @max_length, acc \\ <<>>, line_length \\ 0)
 
-  def encode(<<>>, _, acc, _) do
-    acc
-    |> Enum.reverse()
-    |> Enum.join()
-  end
+  def encode(<<>>, _, acc, _), do: acc
 
   # Encode ASCII characters in range 0x20..0x3C.
   # Encode ASCII characters in range 0x3E..0x7E, except 0x3F (question mark)
-  def encode(<<char, tail::binary>>, max_length, acc, line_length) when char in ?!..?< or char in ?@..?~ or char == ?> do
+  def encode(<<char, tail::binary>>, max_length, acc, line_length)
+      when char in ?!..?< or char in ?@..?~ or char == ?> do
     if line_length < max_length - 1 do
-      encode(tail, max_length, [<<char>> | acc], line_length + 1)
+      encode(tail, max_length, acc <> <<char>>, line_length + 1)
     else
-      encode(tail, max_length, [<<char>>, @new_line | acc], 1)
+      encode(tail, max_length, acc <> @new_line <> <<char>>, 1)
     end
   end
 
@@ -42,18 +39,18 @@ defmodule Mail.Encoders.QuotedPrintable do
     # if remaining > 0 do
     if byte_size(tail) > 0 do
       if line_length < max_length - 1 do
-        encode(tail, max_length, [<<char>> | acc], line_length + 1)
+        encode(tail, max_length, acc <> <<char>>, line_length + 1)
       else
-        encode(tail, max_length, [<<char>>, @new_line | acc], 1)
+        encode(tail, max_length, acc <> @new_line <> <<char>>, 1)
       end
     else
       escaped = "=" <> Base.encode16(<<char>>)
       line_length = line_length + byte_size(escaped)
 
       if line_length <= max_length do
-        encode(tail, max_length, [escaped | acc], line_length)
+        encode(tail, max_length, acc <> escaped, line_length)
       else
-        encode(tail, max_length, [escaped, @new_line | acc], byte_size(escaped))
+        encode(tail, max_length, acc <> @new_line <> escaped, byte_size(escaped))
       end
     end
   end
@@ -64,9 +61,9 @@ defmodule Mail.Encoders.QuotedPrintable do
     line_length = line_length + byte_size(escaped)
 
     if line_length < max_length do
-      encode(tail, max_length, [escaped | acc], line_length)
+      encode(tail, max_length, acc <> escaped, line_length)
     else
-      encode(tail, max_length, [escaped, @new_line | acc], byte_size(escaped))
+      encode(tail, max_length, acc <> @new_line <> escaped, byte_size(escaped))
     end
   end
 


### PR DESCRIPTION
Hi! I noticed huge memory usage when encoding big emails (~15MB, that big mainly because of someone's huge base64-encoded inline image in their mail signature) after investigation, I found that currently the code builds a list of small binaries, reverses and joins it. As per the [Erlang Efficiency Guide](https://www.erlang.org/doc/efficiency_guide/binaryhandling.html#constructing-binaries), appending to binaries is well optimized and should perform better.

I also confirmed the functions can be tail-call optimized the way they're written currently, with returning `if` expressions (at least on newest OTP 25).

Similarly to https://github.com/DockYard/elixir-mail/pull/86 , here is the benchmark used and results:

```elixir
len = 1024 * 1024 * 15
bin =
  (len * 2)
  |> :crypto.strong_rand_bytes()
  |> Base.encode64()
  |> String.slice(0, len)

Benchee.run(%{
  "OldQuotedPrintable.encode/1" => fn ->
    Mail.Encoders.OldQuotedPrintable.encode(bin)
  end,
  "BinaryAccQuotedPrintable.encode/1" => fn ->
    Mail.Encoders.QuotedPrintable.encode(bin)
  end,
}, time: 10, memory_time: 2)
```

Results:
```elixir
# mix run bench.exs
Operating System: Linux
CPU Information: AMD Ryzen 9 5900HX with Radeon Graphics
Number of Available Cores: 16
Available memory: 13.58 GB
Elixir 1.14.0-dev
Erlang 25.0

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 10 s
memory time: 2 s
reduction time: 0 ns
parallel: 1
inputs: none specified
Estimated total run time: 28 s

Benchmarking BinaryAccQuotedPrintable.encode/1 ...
Benchmarking OldQuotedPrintable.encode/1 ...

Name                                        ips        average  deviation         median         99th %
BinaryAccQuotedPrintable.encode/1          2.73         0.37 s     ±2.48%         0.37 s         0.38 s
OldQuotedPrintable.encode/1                0.23         4.29 s     ±0.93%         4.27 s         4.34 s

Comparison: 
BinaryAccQuotedPrintable.encode/1          2.73
OldQuotedPrintable.encode/1                0.23 - 11.73x slower +3.93 s

Memory usage statistics:

Name                                 Memory usage
BinaryAccQuotedPrintable.encode/1         0.59 GB
OldQuotedPrintable.encode/1               1.06 GB - 1.81x memory usage +0.48 GB

**All measurements for memory usage were the same**
```