### PR TITLE
Custom rfc2822 body decoder

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/config/config.exs
+++ b/config/config.exs
@@ -27,4 +27,4 @@ import Config
 # Configuration from the imported file will override the ones defined
 # here (which is why it is important to import them last).
 #
-#     import_config "#{Mix.env}.exs"
+import_config "#{config_env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,1 @@
+import Config

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,1 @@
+import Config

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,1 +1,3 @@
 import Config
+
+config :mail, rfc2822_body_decoder: Mail.RFC2822BodyDecoderProxy

--- a/lib/mail/parsers/rfc_2822.ex
+++ b/lib/mail/parsers/rfc_2822.ex
@@ -7,6 +7,22 @@ defmodule Mail.Parsers.RFC2822 do
 
       Mail.Parsers.RFC2822.parse(message)
       %Mail.Message{body: "Some message", headers: %{to: ["user@example.com"], from: "other@example.com", subject: "Read this!"}}
+
+  Note that 7bit and 8bit decoders by default will remove CRLF
+  line separation sequences. This is the correct behaviour,
+  as stated in [RFC 2045](https://tools.ietf.org/html/rfc2045#section-2.7)
+  "CR and LF octets only occur as part of CRLF line separation sequences".
+
+  Unfortunately there are a lot of broken mail agents that
+  don't produce correct headers, so it's possible to override
+  the body decoder as follows:
+
+      config :mail, rfc2822_body_decoder: CustomRFC2822BodyDecoder
+
+  A more relaxed decoder is also provided that will leave CRLF separator
+  in body parts when there is a `Content-Type: message/rfc822` header:
+
+      config :mail, rfc2822_body_decoder: Mail.Parsers.RFC2822.BodyDecoder.Permissive
   """
 
   alias Mail.Parsers.RFC2822.BodyDecoder

--- a/lib/mail/parsers/rfc_2822/body_decoder.ex
+++ b/lib/mail/parsers/rfc_2822/body_decoder.ex
@@ -1,0 +1,3 @@
+defmodule Mail.Parsers.RFC2822.BodyDecoder do
+  @callback decode(body :: binary, Mail.Message.t()) :: binary
+end

--- a/lib/mail/parsers/rfc_2822/body_decoder/permissive.ex
+++ b/lib/mail/parsers/rfc_2822/body_decoder/permissive.ex
@@ -1,0 +1,36 @@
+defmodule Mail.Parsers.RFC2822.BodyDecoder.Permissive do
+  @behaviour Mail.Parsers.RFC2822.BodyDecoder
+
+  @plain_encodings ["7bit", "8bit", "binary"]
+
+  @impl true
+  def decode(body, message) do
+    transfer_encoding = content_transfer_encoding(message)
+
+    # The problem with these encodings is that we are not sure if CRLF
+    # are actually part of the body or they are there to split lines
+    # in order to meet the line length limit of 998 characters.
+    # For parts with `Content-Type: message/rfc822` we need to preserve
+    # everything to be sure we can later parse them.
+    if transfer_encoding in @plain_encodings and content_type(message) == "message/rfc822" do
+      Mail.Encoder.decode(body, "binary")
+    else
+      body
+      |> String.trim_trailing()
+      |> Mail.Encoder.decode(transfer_encoding)
+    end
+  end
+
+  @spec content_transfer_encoding(Mail.Message.t()) :: String.t()
+  defp content_transfer_encoding(message) do
+    Mail.Message.get_header(message, "content-transfer-encoding") || "binary"
+  end
+
+  @spec content_type(Mail.Message.t()) :: String.t() | nil
+  defp content_type(message) do
+    case Mail.Message.get_header(message, "content-type") do
+      [content_type | _] -> content_type
+      _ -> nil
+    end
+  end
+end

--- a/lib/mail/parsers/rfc_2822/body_decoder/strict.ex
+++ b/lib/mail/parsers/rfc_2822/body_decoder/strict.ex
@@ -1,0 +1,12 @@
+defmodule Mail.Parsers.RFC2822.BodyDecoder.Strict do
+  @behaviour Mail.Parsers.RFC2822.BodyDecoder
+
+  @impl true
+  def decode(body, message) do
+    transfer_encoding = Mail.Message.get_header(message, "content-transfer-encoding")
+
+    body
+    |> String.trim_trailing()
+    |> Mail.Encoder.decode(transfer_encoding)
+  end
+end

--- a/test/support/rfc2822_body_decoder_proxy.ex
+++ b/test/support/rfc2822_body_decoder_proxy.ex
@@ -1,16 +1,59 @@
 defmodule Mail.RFC2822BodyDecoderProxy do
-  use Agent
+  use GenServer
 
   @behaviour Mail.Parsers.RFC2822.BodyDecoder
 
   @strict_impl Mail.Parsers.RFC2822.BodyDecoder.Strict
   @permissive_impl Mail.Parsers.RFC2822.BodyDecoder.Permissive
 
-  def start_link(impl \\ @strict_impl), do: Agent.start_link(fn -> impl end, name: __MODULE__)
+  def start_link(opts \\ []), do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)
 
-  def strict_impl, do: Agent.update(__MODULE__, fn _ -> @strict_impl end)
-  def permissive_impl, do: Agent.update(__MODULE__, fn _ -> @permissive_impl end)
+  def strict_impl, do: GenServer.call(__MODULE__, {:set_impl, @strict_impl})
 
-  @impl true
-  def decode(body, message), do: Agent.get(__MODULE__, & &1).decode(body, message)
+  def permissive_impl, do: GenServer.call(__MODULE__, {:set_impl, @permissive_impl})
+
+  @impl Mail.Parsers.RFC2822.BodyDecoder
+  def decode(body, message) do
+    case GenServer.call(__MODULE__, {:decode, body, message}) do
+      {:ok, decoded} ->
+        decoded
+
+      {:error, :pid_not_found} ->
+        raise RuntimeError, "You should set an impl module for decoder proxy"
+    end
+  end
+
+  @impl GenServer
+  def init(opts), do: {:ok, {Keyword.get(opts, :default_impl), %{}}}
+
+  @impl GenServer
+  def handle_call({:set_impl, impl}, {test_pid, _tag}, {default_impl, pid_map}) do
+    Process.monitor(test_pid)
+
+    {:reply, :ok, {default_impl, Map.put(pid_map, test_pid, impl)}}
+  end
+
+  def handle_call({:decode, body, message}, {test_pid, _tag}, {nil, pid_map} = state) do
+    case Map.get(pid_map, test_pid) do
+      nil ->
+        {:reply, {:error, :pid_not_found}, state}
+
+      impl ->
+        {:reply, {:ok, impl.decode(body, message)}, state}
+    end
+  end
+
+  def handle_call({:decode, body, message}, {test_pid, _tag}, {default_impl, pid_map} = state) do
+    case Map.get(pid_map, test_pid) do
+      nil ->
+        {:reply, {:ok, default_impl.decode(body, message)}, state}
+
+      impl ->
+        {:reply, {:ok, impl.decode(body, message)}, state}
+    end
+  end
+
+  @impl GenServer
+  def handle_info({:DOWN, _ref, :process, test_pid, _reason}, {default_impl, pid_map}),
+    do: {:noreply, {default_impl, Map.delete(pid_map, test_pid)}}
 end

--- a/test/support/rfc2822_body_decoder_proxy.ex
+++ b/test/support/rfc2822_body_decoder_proxy.ex
@@ -1,0 +1,16 @@
+defmodule Mail.RFC2822BodyDecoderProxy do
+  use Agent
+
+  @behaviour Mail.Parsers.RFC2822.BodyDecoder
+
+  @strict_impl Mail.Parsers.RFC2822.BodyDecoder.Strict
+  @permissive_impl Mail.Parsers.RFC2822.BodyDecoder.Permissive
+
+  def start_link(impl \\ @strict_impl), do: Agent.start_link(fn -> impl end, name: __MODULE__)
+
+  def strict_impl, do: Agent.update(__MODULE__, fn _ -> @strict_impl end)
+  def permissive_impl, do: Agent.update(__MODULE__, fn _ -> @permissive_impl end)
+
+  @impl true
+  def decode(body, message), do: Agent.get(__MODULE__, & &1).decode(body, message)
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,3 @@
+Mail.RFC2822BodyDecoderProxy.start_link()
+
 ExUnit.start()

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,3 @@
-Mail.RFC2822BodyDecoderProxy.start_link()
+Mail.RFC2822BodyDecoderProxy.start_link(default_impl: Mail.Parsers.RFC2822.BodyDecoder.Strict)
 
 ExUnit.start()


### PR DESCRIPTION
I'm struggling with parsing mails like this one:

```elixir
message_literal = """
Content-Type: message/rfc822; name="postacert.eml"\r
Content-Disposition: inline; filename="postacert.eml"\r
Content-Transfer-Encoding: 7bit\r
\r
Date: Mon, 23 May 2022 17:54:45 +0200\r
Subject: This is some test subject\r
\r
hello, everybody\r
\r
"""
```

as you can see `content-transfer-encoding` header is set to `7bit`, while the body contains another message (`message/rfc822`).
Ideally I'd like to recursively parse the body, but `SevenBit` and `EightBit` decoders strip `\r\n`, so this won't work:

```elixir
%Mail.Message{body: body} = Mail.Parsers.RFC2822.parse(message_literal)
Mail.Parsers.RFC2822.parse(body) # (FunctionClauseError) no function clause matching in Mail.Parsers.RFC2822.extract_headers/2
```

## Changes proposed in this pull request

Since the current behaviour is correct, by default nothing changes but the user will be able to inject a custom body decoder:
```elixir
config :mail, rfc2822_body_decoder: CustomRFC2822BodyDecoder
```
or use a less strict decoder that allows to successfully decode the above mentioned message:
```elixir
# config.exs
config :mail, rfc2822_body_decoder: Mail.Parsers.RFC2822.BodyDecoder.Permissive

# ...
%Mail.Message{body: body} = Mail.Parsers.RFC2822.parse(message_literal)

Mail.Parsers.RFC2822.parse(body) == %Mail.Message{
  body: "hello, everybody",
  headers: %{
    "date" => {{2022, 5, 23}, {17, 54, 45}},
    "subject" => "This is some test subject"
  },
  multipart: false,
  parts: []
}
```

let me know if looks good, cheers! :beers: 