### PR TITLE
Split content on CRLF or LF

### DIFF
--- a/lib/mail/parsers/rfc_2822.ex
+++ b/lib/mail/parsers/rfc_2822.ex
@@ -24,7 +24,7 @@ defmodule Mail.Parsers.RFC2822 do
   end
 
   def parse(content),
-    do: content |> String.split("\r\n") |> Enum.map(&String.trim_trailing/1) |> parse
+    do: content |> String.split(~r/(\r\n|\n)/) |> Enum.map(&String.trim_trailing/1) |> parse
 
   defp extract_headers(list, headers \\ [])
 

--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -696,6 +696,28 @@ defmodule Mail.Parsers.RFC2822Test do
     assert message.headers["content-type"] == ["text/html", {"charset", "us-ascii"}]
   end
 
+  test "parses mail with LF instead of CRLF characters" do
+    message =
+      Mail.Parsers.RFC2822.parse("""
+      To: user@example.com
+      From: me@example.com
+      Reply-To: otherme@example.com
+      Subject: Test Email
+      Content-Type: text/plain; foo=bar;
+        baz=qux;
+
+      This is the body!
+      It has more than one line
+      """)
+
+    assert message.headers["to"] == ["user@example.com"]
+    assert message.headers["from"] == "me@example.com"
+    assert message.headers["reply-to"] == "otherme@example.com"
+    assert message.headers["subject"] == "Test Email"
+    assert message.headers["content-type"] == ["text/plain", {"foo", "bar"}, {"baz", "qux"}]
+    assert message.body == "This is the body!\r\nIt has more than one line"
+  end
+
   defp parse_email(email),
     do: email |> convert_crlf |> Mail.Parsers.RFC2822.parse()
 


### PR DESCRIPTION
## Changes proposed in this pull request

Some emails from newsletters don't comply strictly with the RFC2822. One example is Substack. Substack emails only have LF endings.

This PR allows splitting lines by CRLF or LF.
