### PR TITLE
Fix 7-bit decoding to preserve line breaks but restore wrapped lines

### DIFF
--- a/lib/mail/encoders/seven_bit.ex
+++ b/lib/mail/encoders/seven_bit.ex
@@ -38,14 +38,19 @@ defmodule Mail.Encoders.SevenBit do
   @doc """
   Decodes a 7-bit encoded string.
   """
-  def decode(string), do: do_decode(string, "")
-  defp do_decode(<<>>, acc), do: acc
+  def decode(encoded_string), do: do_decode(encoded_string, "", 0)
 
-  defp do_decode(<<head, tail::binary>>, acc) do
-    {decoded, tail} = decode_char(head, tail)
-    do_decode(tail, acc <> decoded)
+  defp do_decode(<<>>, acc, _line_length), do: acc
+
+  defp do_decode(<<"\r\n", tail::binary>>, acc, 998) do
+    do_decode(tail, acc, 0)
   end
 
-  defp decode_char(?\r, <<?\n, tail::binary>>), do: {"", tail}
-  defp decode_char(char, <<tail::binary>>), do: {<<char>>, tail}
+  defp do_decode(<<head, tail::binary>>, acc, line_length) do
+    {decoded, tail, length} = decode_char(head, tail)
+    do_decode(tail, acc <> decoded, line_length + length)
+  end
+
+  defp decode_char(char, tail) when char in @valid_chars, do: {<<char>>, tail, 1}
+  defp decode_char(char, _tail), do: raise(ArgumentError, message: "invalid character: #{char}")
 end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Mail.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/DockYard/elixir-mail"
-  @version "0.3.1"
+  @version "0.4.0"
 
   def project do
     [

--- a/test/mail/encoders/seven_bit_test.exs
+++ b/test/mail/encoders/seven_bit_test.exs
@@ -5,7 +5,7 @@ defmodule Mail.Encoders.SevenBitTest do
     assert Mail.Encoders.SevenBit.encode("") == ""
   end
 
-  test "encode wraps lines longer than 1000 characters" do
+  test "encode wraps lines longer than 998 characters" do
     message = String.duplicate("-", 2000)
     encoding = Mail.Encoders.SevenBit.encode(message)
     assert binary_part(encoding, 998, 2) == "\r\n"
@@ -29,8 +29,27 @@ defmodule Mail.Encoders.SevenBitTest do
     assert Mail.Encoders.SevenBit.decode("") == ""
   end
 
-  test "decode removes <CR><LF> pairs" do
+  test "decode preserves <CR><LF> pairs" do
     message = "This is a \r\ntest\r\n"
-    assert Mail.Encoders.SevenBit.decode(message) == "This is a test"
+    assert Mail.Encoders.SevenBit.decode(message) == "This is a \r\ntest\r\n"
+  end
+
+  test "decode removes crlf wrapping characters" do
+    message = String.duplicate("-", 1000)
+    encoded = Mail.Encoders.SevenBit.encode(message)
+    assert binary_part(encoded, 998, 2) == "\r\n"
+    assert message == Mail.Encoders.SevenBit.decode(encoded)
+  end
+
+  test "decode raises if any character isn't 7-bit ASCII" do
+    assert_raise ArgumentError, fn ->
+      Mail.Encoders.SevenBit.decode("hełło")
+    end
+  end
+
+  test "decode raises if any character is <NUL>" do
+    assert_raise ArgumentError, fn ->
+      Mail.Encoders.SevenBit.decode("\0")
+    end
   end
 end


### PR DESCRIPTION
The current implementation of 7-bit encoding wraps lines longer than 998, as it should, but then removes all line breaks on decoding—but it should only remove those added due to line wrapping.
This pull request also validates the character set by raising on invalid characters in the same way the encoding does.
Because of the change in decoding, this is a breaking change