### PR TITLE
Fix decoding of quoted printable encoded words containing underscores as spaces

### DIFF
--- a/lib/mail/parsers/rfc_2822.ex
+++ b/lib/mail/parsers/rfc_2822.ex
@@ -328,7 +328,7 @@ defmodule Mail.Parsers.RFC2822 do
         decoded_string =
           case String.upcase(encoding) do
             "Q" ->
-              Mail.Encoders.QuotedPrintable.decode(encoded_string)
+              Mail.Encoders.QuotedPrintable.decode(String.replace(encoded_string, "_", " "))
 
             "B" ->
               Mail.Encoders.Base64.decode(encoded_string)

--- a/test/mail/message_test.exs
+++ b/test/mail/message_test.exs
@@ -230,6 +230,15 @@ defmodule Mail.MessageTest do
     assert %Mail.Message{headers: %{"subject" => ^subject}} = Mail.Parsers.RFC2822.parse(txt)
   end
 
+  test "UTF-8 in subject (quoted printable with spaces, RFC 2047§4.2 (2)" do
+    subject = "test 😀 test"
+
+    mail =
+      "Subject: =?UTF-8?Q?test_" <> Mail.Encoders.QuotedPrintable.encode("😀") <> "_test?=\r\n\r\n"
+
+    assert %Mail.Message{headers: %{"subject" => ^subject}} = Mail.Parsers.RFC2822.parse(mail)
+  end
+
   test "UTF-8 in other header" do
     file_name = "READMEüä.md"
 

--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -449,7 +449,7 @@ defmodule Mail.Parsers.RFC2822Test do
       parse_email("""
       To: user@example.com
       From: me@example.com
-      Subject: =?utf-8?Q?=C2=A3?=200.00 =?UTF-8?q?=F0=9F=92=B5?=
+      Subject: =?utf-8?Q?=C2=A3?=200.00=?UTF-8?q?_=F0=9F=92=B5?=
       Content-Type: multipart/mixed;
       	boundary="----=_Part_295474_20544590.1456382229928"
 


### PR DESCRIPTION
According to [RFC 2047§4.2](https://www.rfc-editor.org/rfc/rfc2047.html#section-4.2), the Q encoding has a special case where a space can be encoded as an underscore
`test =?UTF-8?Q?=F0=9F=92=B5?= test` can also be encoded as `=?UTF-8?Q?test_=F0=9F=92=B5_test?=`
This pull request leaves our encoding (which chooses the first option when encoding) and updates our decoding to support the second case.