### PR TITLE
Fix 8-bit decoding to preserve line breaks but restore wrapped lines

### DIFF
--- a/test/mail/encoders/eight_bit_test.exs
+++ b/test/mail/encoders/eight_bit_test.exs
@@ -23,8 +23,21 @@ defmodule Mail.Encoders.EightBitTest do
     assert Mail.Encoders.EightBit.decode("") == ""
   end
 
-  test "decode removes <CR><LF> pairs" do
+  test "decode preserves <CR><LF> pairs" do
     message = "This is a \r\ntest\r\n"
-    assert Mail.Encoders.EightBit.decode(message) == "This is a test"
+    assert Mail.Encoders.EightBit.decode(message) == "This is a \r\ntest\r\n"
+  end
+
+  test "decode removes crlf wrapping characters" do
+    message = String.duplicate("-", 1000)
+    encoded = Mail.Encoders.EightBit.encode(message)
+    assert binary_part(encoded, 998, 2) == "\r\n"
+    assert message == Mail.Encoders.EightBit.decode(encoded)
+  end
+
+  test "decode raises if any character is <NUL>" do
+    assert_raise ArgumentError, fn ->
+      Mail.Encoders.EightBit.decode("\0")
+    end
   end
 end


### PR DESCRIPTION
The current implementation of 8-bit encoding wraps lines longer than 998, as it should, but then removes all line breaks on decoding—but it should only remove those added due to line wrapping.
This pull request also validates the character set by raising on a null character in the same way the encoding does.
Because of the change in decoding, this is a breaking change (But we haven’t released the version increase from the 7-bit decoding fix #164 so there’s no need for a further version increase.)