### PR TITLE
Ignore space between two encoded words (as per RFC 2047)

### DIFF
--- a/lib/mail/parsers/rfc_2822.ex
+++ b/lib/mail/parsers/rfc_2822.ex
@@ -258,7 +258,10 @@ defmodule Mail.Parsers.RFC2822 do
     [name, body] = String.split(header, ":", parts: 2)
     key = String.downcase(name)
     decoded = parse_encoded_word(body)
-    headers = put_header(message.headers, key, String.downcase(name) |> parse_header_value(decoded))
+
+    headers =
+      put_header(message.headers, key, String.downcase(name) |> parse_header_value(decoded))
+
     message = %{message | headers: headers}
     parse_headers(message, tail)
   end
@@ -333,6 +336,9 @@ defmodule Mail.Parsers.RFC2822 do
             "B" ->
               Mail.Encoders.Base64.decode(encoded_string)
           end
+
+        # Remove space if immediately followed by another encoded word string
+        remainder = Regex.replace(~r/\s+\=\?/, remainder, "=?")
 
         decoded_string <> parse_encoded_word(remainder)
 

--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -457,6 +457,19 @@ defmodule Mail.Parsers.RFC2822Test do
     assert message.headers["x-reallylongheadernamethatcausesbodytowrap"] == "BodyOnNewLine"
   end
 
+  test "parse header with folded encoded word" do
+    # This is seen in the examples in https://www.rfc-editor.org/rfc/rfc2047.html#section-8
+    message =
+      parse_email("""
+      X-Encoded-Word: =?utf-8?Q?h=CE=B5=C5=82=C5=82=C3=B8=20w=C3=B8?=
+        =?utf-8?Q?r=C5=82d?=
+
+      Body
+      """)
+
+    assert message.headers["x-encoded-word"] == "hεłłø wørłd"
+  end
+
   test "allow empty body (RFC2822 §3.5)" do
     message =
       parse_email("""


### PR DESCRIPTION
When more than one encoded word is folded, the two need to be concatenated without the space to correctly decode the text. [RFC 2047 §5](https://www.rfc-editor.org/rfc/rfc2047.html#section-5)
This fix removes any space between two encoded words after unfolding