### PR TITLE
Better inline charset handling for get_html

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ mail-*.tar
 
 # Temporary files for e.g. tests
 /tmp
+
+# ASDF tool specifications
+.tool-versions

--- a/lib/mail.ex
+++ b/lib/mail.ex
@@ -159,9 +159,9 @@ defmodule Mail do
     end)
   end
 
-  def get_html(%Mail.Message{headers: %{"content-type" => "text/html"}} = message), do: message
+  def get_html(%Mail.Message{headers: %{"content-type" => "text/html" <> _}} = message), do: message
 
-  def get_html(%Mail.Message{headers: %{"content-type" => ["text/html", _]}} = message),
+  def get_html(%Mail.Message{headers: %{"content-type" => ["text/html" | _]}} = message),
     do: message
 
   def get_html(%Mail.Message{}), do: nil

--- a/test/mail_test.exs
+++ b/test/mail_test.exs
@@ -267,7 +267,7 @@ defmodule MailTest do
     assert Mail.get_html(mail) == mail
   end
 
-  test "get_html with singlepart and content-type" do
+  test "get_html with singlepart and content-type with inline charset spec" do
     mail =
       Mail.put_html(Mail.build(), "<h1>Some HTML</h1>")
       |> Mail.Message.put_content_type("text/html; charset=UTF-8")

--- a/test/mail_test.exs
+++ b/test/mail_test.exs
@@ -267,6 +267,14 @@ defmodule MailTest do
     assert Mail.get_html(mail) == mail
   end
 
+  test "get_html with singlepart and content-type" do
+    mail =
+      Mail.put_html(Mail.build(), "<h1>Some HTML</h1>")
+      |> Mail.Message.put_content_type("text/html; charset=UTF-8")
+
+    assert Mail.get_html(mail) == mail
+  end
+
   test "get_html with singlepart not html" do
     mail = Mail.put_text(Mail.build(), "Some text")
     assert is_nil(Mail.get_html(mail))


### PR DESCRIPTION
<!-- If this pull request addresses an issue please provide the issue number here -->
Closes #171.

## Changes proposed in this pull request
Aligning `get_html` matches with get_text to ensure that we match on the same types of content type specifications between the two, except for the obvious actual content type part differences.
