### PR TITLE
Fix quoted-printable encoding for reserved chars, RFC 2047, section 4.2(3)

### DIFF
--- a/lib/mail/encoders/quoted_printable.ex
+++ b/lib/mail/encoders/quoted_printable.ex
@@ -8,6 +8,7 @@ defmodule Mail.Encoders.QuotedPrintable do
 
   @new_line "=\r\n"
   @max_length 76
+  @reserved_chars [?=, ??, ?_]
 
   @doc """
   Encodes a string into a quoted-printable encoded string.
@@ -23,10 +24,9 @@ defmodule Mail.Encoders.QuotedPrintable do
 
   def encode(<<>>, _, acc, _), do: acc
 
-  # Encode ASCII characters in range 0x20..0x3C.
-  # Encode ASCII characters in range 0x3E..0x7E, except 0x3F (question mark)
+  # Encode ASCII characters in range 0x20..0x7E, except reserved symbols: 0x3F (question mark), 0x3D (equal sign) and 0x5F (underscore)
   def encode(<<char, tail::binary>>, max_length, acc, line_length)
-      when char in ?!..?< or char in ?@..?~ or char == ?> do
+      when char in ?!..?~ and char not in @reserved_chars do
     if line_length < max_length - 1 do
       encode(tail, max_length, acc <> <<char>>, line_length + 1)
     else

--- a/test/mail/encoders/quoted_printable_test.exs
+++ b/test/mail/encoders/quoted_printable_test.exs
@@ -12,8 +12,14 @@ defmodule Mail.Encoders.QuotedPrintableTest do
     ascii_upper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
     assert Mail.Encoders.QuotedPrintable.encode(ascii_upper) == ascii_upper
 
-    ascii_symbols = "!\"#$%&\'()*+,-./0123456789:;<>@[\\]^_`{|}~"
+    ascii_symbols = "!\"#$%&\'()*+,-./0123456789:;<>@[\\]^`{|}~"
     assert Mail.Encoders.QuotedPrintable.encode(ascii_symbols) == ascii_symbols
+  end
+
+  # RFC 2047, section 4.2(3)
+  test "encodes reserved characters" do
+    reserved_characters = "=?_"
+    assert Mail.Encoders.QuotedPrintable.encode(reserved_characters) == "=3D=3F=5F"
   end
 
   test "encodes question mark sign" do


### PR DESCRIPTION
Quoted printable encoding was leaving the _ (underscore) unencoded in violation of RFC 2047