### PR TITLE
Failing test for error on parsing for Windows-1252 encoded filenames

### DIFF
--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -800,7 +800,34 @@ defmodule Mail.Parsers.RFC2822Test do
       Content-Transfer-Encoding: base64
 
       JVBERi0xLjcKJeLjz9MKNiAwIG9iago8PCAvQ3JlYXRvciAoT3BlblRleHQgRXhzdHJlYW0gVmVy
-      ------=_Part_295474_20544590.1456382229928--
+
+      ------=_Part_295474_20544590.1456382229928
+      Content-Type: application/pdf;
+        name="=?windows-1258?Q?Pre=ECsentation.pdf?="
+      Content-Description: =?windows-1258?Q?Pre=ECsentation.pdf?=
+      Content-Disposition: attachment;
+        filename="=?windows-1258?Q?Pre=ECsentation.pdf?="; size=3827236;
+        creation-date="Wed, 11 Sep 2024 09:27:41 GMT";
+        modification-date="Wed, 09 Oct 2024 08:27:14 GMT"
+      Content-ID: <f_m0xno2c63>
+      Content-Transfer-Encoding: base64
+
+      JVBERi0xLjcKJeLjz9MKNiAwIG9iago8PCAvQ3JlYXRvciAoT3BlblRleHQgRXhzdHJlYW0gVmVy
+
+      ------=_Part_295474_20544590.1456382229928
+      Content-Type: application/octet-stream;
+        name="=?Windows-1252?Q?ID_S=E9_-_Liste_inscrits.xlsx?="
+      Content-Description:
+      =?Windows-1252?Q?ID_S=E9_-_Liste_inscrits.xlsx?=
+      Content-Disposition: attachment;
+        filename="=?Windows-1252?Q?ID_S=E9_-_Liste_inscrits.xlsx?=";
+        size=19791; creation-date="Tue, 08 Oct 2024 14:16:55 GMT";
+        modification-date="Tue, 08 Oct 2024 14:16:55 GMT"
+      Content-Transfer-Encoding: base64
+
+      JVBERi0xLjcKJeLjz9MKNiAwIG9iago8PCAvQ3JlYXRvciAoT3BlblRleHQgRXhzdHJlYW0gVmVy
+
+      ------=_Part_295474_20544590.1456382229928
       """)
 
     assert parts = message.parts

--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -775,6 +775,37 @@ defmodule Mail.Parsers.RFC2822Test do
              part.headers["content-type"]
   end
 
+  test "parses Windows-1252 encoded filenames" do
+    message =
+      parse_email("""
+      To: user@example.com
+      From: me@example.com
+      Subject: Test
+      Content-Type: multipart/mixed;
+      	boundary="----=_Part_295474_20544590.1456382229928"
+
+      ------=_Part_295474_20544590.1456382229928
+      Content-Type: text/plain
+
+      This is some text
+
+      ------=_Part_295474_20544590.1456382229928
+      Content-Type: application/octet-stream;
+        name="=?Windows-1252?Q?Imagin=E9.pdf?="
+      Content-Description: =?Windows-1252?Q?Imagine=E9.pdf?=
+      Content-Disposition: attachment;
+        filename="=?Windows-1252?Q?Imagine=E9.pdf?="; size=864872;
+        creation-date="Tue, 08 Oct 2024 14:16:59 GMT";
+        modification-date="Tue, 08 Oct 2024 14:16:59 GMT"
+      Content-Transfer-Encoding: base64
+
+      JVBERi0xLjcKJeLjz9MKNiAwIG9iago8PCAvQ3JlYXRvciAoT3BlblRleHQgRXhzdHJlYW0gVmVy
+      ------=_Part_295474_20544590.1456382229928--
+      """)
+
+    assert parts = message.parts
+  end
+
   test "content-type mixed with no body" do
     message =
       parse_email("""


### PR DESCRIPTION
Failing test for the following error:

```elixir
FunctionClauseError: ** (FunctionClauseError) no function clause matching in Mail.Parsers.RFC2822.parse_quoted_string/2
lib/mail/parsers/rfc_2822.ex:384 in Mail.Parsers.RFC2822.parse_quoted_string("...", "...")
lib/mail/parsers/rfc_2822.ex:366 in Mail.Parsers.RFC2822.parse_structured_header_value/4
lib/mail/parsers/rfc_2822.ex:310 in Mail.Parsers.RFC2822.parse_header_value/2
lib/mail/parsers/rfc_2822.ex:261 in **Mail.Parsers.RFC2822.parse_headers/2**
```
on mails with Windows-1252 encoded filenames