### PR TITLE
Add charset handler option to RFC2822 parser

### DIFF
--- a/lib/mail/parsers/rfc_2822.ex
+++ b/lib/mail/parsers/rfc_2822.ex
@@ -429,13 +429,13 @@ defmodule Mail.Parsers.RFC2822 do
 
   defp parse_quoted_string(string, acc \\ "")
 
-  defp parse_quoted_string(<<"\\", char::utf8, rest::binary>>, acc),
-    do: parse_quoted_string(rest, <<acc::binary, char::utf8>>)
+  defp parse_quoted_string(<<"\\", char, rest::binary>>, acc),
+    do: parse_quoted_string(rest, <<acc::binary, char>>)
 
   defp parse_quoted_string(<<"\"", rest::binary>>, acc), do: {acc, rest}
 
-  defp parse_quoted_string(<<char::utf8, rest::binary>>, acc),
-    do: parse_quoted_string(rest, <<acc::binary, char::utf8>>)
+  defp parse_quoted_string(<<char, rest::binary>>, acc),
+    do: parse_quoted_string(rest, <<acc::binary, char>>)
 
   defp parse_received_value(value) do
     case String.split(value, ";") do

--- a/lib/mail/proplist.ex
+++ b/lib/mail/proplist.ex
@@ -86,6 +86,8 @@ defmodule Mail.Proplist do
   * `list` - the list to look in
   * `key` - the key of the pair to retrieve it's value
   """
+  def get(nil, _key), do: nil
+
   def get(list, key) do
     case :proplists.get_value(key, list) do
       :undefined -> nil

--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -817,8 +817,7 @@ defmodule Mail.Parsers.RFC2822Test do
       ------=_Part_295474_20544590.1456382229928
       Content-Type: application/octet-stream;
         name="=?Windows-1252?Q?ID_S=E9_-_Liste_inscrits.xlsx?="
-      Content-Description:
-      =?Windows-1252?Q?ID_S=E9_-_Liste_inscrits.xlsx?=
+      Content-Description: =?Windows-1252?Q?ID_S=E9_-_Liste_inscrits.xlsx?=
       Content-Disposition: attachment;
         filename="=?Windows-1252?Q?ID_S=E9_-_Liste_inscrits.xlsx?=";
         size=19791; creation-date="Tue, 08 Oct 2024 14:16:55 GMT";
@@ -830,7 +829,12 @@ defmodule Mail.Parsers.RFC2822Test do
       ------=_Part_295474_20544590.1456382229928
       """)
 
-    assert parts = message.parts
+    assert [part1, part2, part3, part4] = message.parts
+
+    assert %{headers: %{"content-type" => ["text/plain" | _]}} = part1
+    assert %{headers: %{"content-type" => ["application/octet-stream", {"name", "Imagin\xE9.pdf"}]}} = part2
+    assert %{headers: %{"content-type" => ["application/pdf", {"name", "Pre\xECsentation.pdf"}]}} = part3
+    assert %{headers: %{"content-type" => ["application/octet-stream", {"name", "ID S\xE9 - Liste inscrits.xlsx"}]}} = part4
   end
 
   test "content-type mixed with no body" do

--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -800,7 +800,34 @@ defmodule Mail.Parsers.RFC2822Test do
       Content-Transfer-Encoding: base64
 
       JVBERi0xLjcKJeLjz9MKNiAwIG9iago8PCAvQ3JlYXRvciAoT3BlblRleHQgRXhzdHJlYW0gVmVy
-      ------=_Part_295474_20544590.1456382229928--
+
+      ------=_Part_295474_20544590.1456382229928
+      Content-Type: application/pdf;
+        name="=?windows-1258?Q?Pre=ECsentation.pdf?="
+      Content-Description: =?windows-1258?Q?Pre=ECsentation.pdf?=
+      Content-Disposition: attachment;
+        filename="=?windows-1258?Q?Pre=ECsentation.pdf?="; size=3827236;
+        creation-date="Wed, 11 Sep 2024 09:27:41 GMT";
+        modification-date="Wed, 09 Oct 2024 08:27:14 GMT"
+      Content-ID: <f_m0xno2c63>
+      Content-Transfer-Encoding: base64
+
+      JVBERi0xLjcKJeLjz9MKNiAwIG9iago8PCAvQ3JlYXRvciAoT3BlblRleHQgRXhzdHJlYW0gVmVy
+
+      ------=_Part_295474_20544590.1456382229928
+      Content-Type: application/octet-stream;
+        name="=?Windows-1252?Q?ID_S=E9_-_Liste_inscrits.xlsx?="
+      Content-Description:
+      =?Windows-1252?Q?ID_S=E9_-_Liste_inscrits.xlsx?=
+      Content-Disposition: attachment;
+        filename="=?Windows-1252?Q?ID_S=E9_-_Liste_inscrits.xlsx?=";
+        size=19791; creation-date="Tue, 08 Oct 2024 14:16:55 GMT";
+        modification-date="Tue, 08 Oct 2024 14:16:55 GMT"
+      Content-Transfer-Encoding: base64
+
+      JVBERi0xLjcKJeLjz9MKNiAwIG9iago8PCAvQ3JlYXRvciAoT3BlblRleHQgRXhzdHJlYW0gVmVy
+
+      ------=_Part_295474_20544590.1456382229928
       """)
 
     assert parts = message.parts

--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -775,6 +775,37 @@ defmodule Mail.Parsers.RFC2822Test do
              part.headers["content-type"]
   end
 
+  test "parses Windows-1252 encoded filenames" do
+    message =
+      parse_email("""
+      To: user@example.com
+      From: me@example.com
+      Subject: Test
+      Content-Type: multipart/mixed;
+      	boundary="----=_Part_295474_20544590.1456382229928"
+
+      ------=_Part_295474_20544590.1456382229928
+      Content-Type: text/plain
+
+      This is some text
+
+      ------=_Part_295474_20544590.1456382229928
+      Content-Type: application/octet-stream;
+        name="=?Windows-1252?Q?Imagin=E9.pdf?="
+      Content-Description: =?Windows-1252?Q?Imagine=E9.pdf?=
+      Content-Disposition: attachment;
+        filename="=?Windows-1252?Q?Imagine=E9.pdf?="; size=864872;
+        creation-date="Tue, 08 Oct 2024 14:16:59 GMT";
+        modification-date="Tue, 08 Oct 2024 14:16:59 GMT"
+      Content-Transfer-Encoding: base64
+
+      JVBERi0xLjcKJeLjz9MKNiAwIG9iago8PCAvQ3JlYXRvciAoT3BlblRleHQgRXhzdHJlYW0gVmVy
+      ------=_Part_295474_20544590.1456382229928--
+      """)
+
+    assert parts = message.parts
+  end
+
   test "content-type mixed with no body" do
     message =
       parse_email("""

--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -784,9 +784,10 @@ defmodule Mail.Parsers.RFC2822Test do
     	boundary="----=_Part_295474_20544590.1456382229928"
 
     ------=_Part_295474_20544590.1456382229928
-    Content-Type: text/plain
+    Content-Type: text/plain; charset="Windows-1252"
+      Content-Transfer-Encoding: quoted-printable
 
-    This is some text
+      fran=E7aise pr=E8s =E0 th=E9=E2tre lumi=E8re
 
     ------=_Part_295474_20544590.1456382229928
     Content-Type: application/octet-stream;

--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -776,65 +776,118 @@ defmodule Mail.Parsers.RFC2822Test do
   end
 
   test "parses Windows-1252 encoded filenames" do
-    message =
-      parse_email("""
-      To: user@example.com
-      From: me@example.com
-      Subject: Test
-      Content-Type: multipart/mixed;
-      	boundary="----=_Part_295474_20544590.1456382229928"
+    email = """
+    To: user@example.com
+    From: me@example.com
+    Subject: Test
+    Content-Type: multipart/mixed;
+    	boundary="----=_Part_295474_20544590.1456382229928"
 
-      ------=_Part_295474_20544590.1456382229928
-      Content-Type: text/plain
+    ------=_Part_295474_20544590.1456382229928
+    Content-Type: text/plain
 
-      This is some text
+    This is some text
 
-      ------=_Part_295474_20544590.1456382229928
-      Content-Type: application/octet-stream;
-        name="=?Windows-1252?Q?Imagin=E9.pdf?="
-      Content-Description: =?Windows-1252?Q?Imagine=E9.pdf?=
-      Content-Disposition: attachment;
-        filename="=?Windows-1252?Q?Imagine=E9.pdf?="; size=864872;
-        creation-date="Tue, 08 Oct 2024 14:16:59 GMT";
-        modification-date="Tue, 08 Oct 2024 14:16:59 GMT"
-      Content-Transfer-Encoding: base64
+    ------=_Part_295474_20544590.1456382229928
+    Content-Type: application/octet-stream;
+      name="=?Windows-1252?Q?Imagin=E9.pdf?="
+    Content-Description: =?Windows-1252?Q?Imagine=E9.pdf?=
+    Content-Disposition: attachment;
+      filename="=?Windows-1252?Q?Imagine=E9.pdf?="; size=864872;
+      creation-date="Tue, 08 Oct 2024 14:16:59 GMT";
+      modification-date="Tue, 08 Oct 2024 14:16:59 GMT"
+    Content-Transfer-Encoding: base64
 
-      JVBERi0xLjcKJeLjz9MKNiAwIG9iago8PCAvQ3JlYXRvciAoT3BlblRleHQgRXhzdHJlYW0gVmVy
+    JVBERi0xLjcKJeLjz9MKNiAwIG9iago8PCAvQ3JlYXRvciAoT3BlblRleHQgRXhzdHJlYW0gVmVy
 
-      ------=_Part_295474_20544590.1456382229928
-      Content-Type: application/pdf;
-        name="=?windows-1258?Q?Pre=ECsentation.pdf?="
-      Content-Description: =?windows-1258?Q?Pre=ECsentation.pdf?=
-      Content-Disposition: attachment;
-        filename="=?windows-1258?Q?Pre=ECsentation.pdf?="; size=3827236;
-        creation-date="Wed, 11 Sep 2024 09:27:41 GMT";
-        modification-date="Wed, 09 Oct 2024 08:27:14 GMT"
-      Content-ID: <f_m0xno2c63>
-      Content-Transfer-Encoding: base64
+    ------=_Part_295474_20544590.1456382229928
+    Content-Type: application/pdf;
+      name="=?windows-1258?Q?Pre=ECsentation.pdf?="
+    Content-Description: =?windows-1258?Q?Pre=ECsentation.pdf?=
+    Content-Disposition: attachment;
+      filename="=?windows-1258?Q?Pre=ECsentation.pdf?="; size=3827236;
+      creation-date="Wed, 11 Sep 2024 09:27:41 GMT";
+      modification-date="Wed, 09 Oct 2024 08:27:14 GMT"
+    Content-ID: <f_m0xno2c63>
+    Content-Transfer-Encoding: base64
 
-      JVBERi0xLjcKJeLjz9MKNiAwIG9iago8PCAvQ3JlYXRvciAoT3BlblRleHQgRXhzdHJlYW0gVmVy
+    JVBERi0xLjcKJeLjz9MKNiAwIG9iago8PCAvQ3JlYXRvciAoT3BlblRleHQgRXhzdHJlYW0gVmVy
 
-      ------=_Part_295474_20544590.1456382229928
-      Content-Type: application/octet-stream;
-        name="=?Windows-1252?Q?ID_S=E9_-_Liste_inscrits.xlsx?="
-      Content-Description: =?Windows-1252?Q?ID_S=E9_-_Liste_inscrits.xlsx?=
-      Content-Disposition: attachment;
-        filename="=?Windows-1252?Q?ID_S=E9_-_Liste_inscrits.xlsx?=";
-        size=19791; creation-date="Tue, 08 Oct 2024 14:16:55 GMT";
-        modification-date="Tue, 08 Oct 2024 14:16:55 GMT"
-      Content-Transfer-Encoding: base64
+    ------=_Part_295474_20544590.1456382229928
+    Content-Type: application/octet-stream;
+      name="=?Windows-1252?Q?ID_S=E9_-_Liste_inscrits.xlsx?="
+    Content-Description: =?Windows-1252?Q?ID_S=E9_-_Liste_inscrits.xlsx?=
+    Content-Disposition: attachment;
+      filename="=?Windows-1252?Q?ID_S=E9_-_Liste_inscrits.xlsx?=";
+      size=19791; creation-date="Tue, 08 Oct 2024 14:16:55 GMT";
+      modification-date="Tue, 08 Oct 2024 14:16:55 GMT"
+    Content-Transfer-Encoding: base64
 
-      JVBERi0xLjcKJeLjz9MKNiAwIG9iago8PCAvQ3JlYXRvciAoT3BlblRleHQgRXhzdHJlYW0gVmVy
+    JVBERi0xLjcKJeLjz9MKNiAwIG9iago8PCAvQ3JlYXRvciAoT3BlblRleHQgRXhzdHJlYW0gVmVy
 
-      ------=_Part_295474_20544590.1456382229928
-      """)
+    ------=_Part_295474_20544590.1456382229928
+    """
 
+    message = parse_email(email)
     assert [part1, part2, part3, part4] = message.parts
 
     assert %{headers: %{"content-type" => ["text/plain" | _]}} = part1
-    assert %{headers: %{"content-type" => ["application/octet-stream", {"name", "Imagin\xE9.pdf"}]}} = part2
-    assert %{headers: %{"content-type" => ["application/pdf", {"name", "Pre\xECsentation.pdf"}]}} = part3
-    assert %{headers: %{"content-type" => ["application/octet-stream", {"name", "ID S\xE9 - Liste inscrits.xlsx"}]}} = part4
+
+    assert %{
+             headers: %{
+               "content-type" => ["application/octet-stream", {"name", "Imagin\xE9.pdf"}]
+             }
+           } = part2
+
+    assert %{headers: %{"content-type" => ["application/pdf", {"name", "Pre\xECsentation.pdf"}]}} =
+             part3
+
+    assert %{
+             headers: %{
+               "content-type" => [
+                 "application/octet-stream",
+                 {"name", "ID S\xE9 - Liste inscrits.xlsx"}
+               ]
+             }
+           } = part4
+
+    # This is a simple character replacement function that simulates charset change from Windows-1252/1258 to UTF-8
+    message =
+      parse_email(email,
+        charset_handler: fn _charset, string ->
+          string
+          |> String.graphemes()
+          |> Enum.map(fn
+            # Windows-1252
+            <<233>> -> "é"
+            # Windows-1258
+            <<236>> -> "\u0301"
+            char -> char
+          end)
+          |> Enum.join()
+        end
+      )
+
+    assert [part1, part2, part3, part4] = message.parts
+    assert %{headers: %{"content-type" => ["text/plain" | _]}} = part1
+
+    assert %{
+             headers: %{
+               "content-type" => ["application/octet-stream", {"name", "Imaginé.pdf"}]
+             }
+           } = part2
+
+    assert %{headers: %{"content-type" => ["application/pdf", {"name", "Présentation.pdf"}]}} =
+             part3
+
+    assert %{
+             headers: %{
+               "content-type" => [
+                 "application/octet-stream",
+                 {"name", "ID Sé - Liste inscrits.xlsx"}
+               ]
+             }
+           } = part4
   end
 
   test "content-type mixed with no body" do
@@ -879,8 +932,8 @@ defmodule Mail.Parsers.RFC2822Test do
     assert message.headers["content-type"] == ["text/html", {"charset", "us-ascii"}]
   end
 
-  defp parse_email(email),
-    do: email |> convert_crlf |> Mail.Parsers.RFC2822.parse()
+  defp parse_email(email, opts \\ []),
+    do: email |> convert_crlf |> Mail.Parsers.RFC2822.parse(opts)
 
   defp parse_recipient(recipient),
     do: Mail.Parsers.RFC2822.parse_recipient_value(recipient)

--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -785,9 +785,9 @@ defmodule Mail.Parsers.RFC2822Test do
 
     ------=_Part_295474_20544590.1456382229928
     Content-Type: text/plain; charset="Windows-1252"
-      Content-Transfer-Encoding: quoted-printable
+    Content-Transfer-Encoding: quoted-printable
 
-      fran=E7aise pr=E8s =E0 th=E9=E2tre lumi=E8re
+    fran=E7aise pr=E8s =E0 th=E9=E2tre lumi=E8re
 
     ------=_Part_295474_20544590.1456382229928
     Content-Type: application/octet-stream;
@@ -833,6 +833,7 @@ defmodule Mail.Parsers.RFC2822Test do
     assert [part1, part2, part3, part4] = message.parts
 
     assert %{headers: %{"content-type" => ["text/plain" | _]}} = part1
+    assert part1.body == "fran\xE7aise pr\xE8s \xE0 th\xE9\xE2tre lumi\xE8re"
 
     assert %{
              headers: %{
@@ -860,9 +861,13 @@ defmodule Mail.Parsers.RFC2822Test do
           |> String.graphemes()
           |> Enum.map(fn
             # Windows-1252
-            <<233>> -> "é"
+            <<0xE0>> -> "à"
+            <<0xE2>> -> "â"
+            <<0xE7>> -> "ç"
+            <<0xE8>> -> "è"
+            <<0xE9>> -> "é"
             # Windows-1258
-            <<236>> -> "\u0301"
+            <<0xEC>> -> "\u0301"
             char -> char
           end)
           |> Enum.join()
@@ -871,6 +876,7 @@ defmodule Mail.Parsers.RFC2822Test do
 
     assert [part1, part2, part3, part4] = message.parts
     assert %{headers: %{"content-type" => ["text/plain" | _]}} = part1
+    assert part1.body == "française près à théâtre lumière"
 
     assert %{
              headers: %{


### PR DESCRIPTION
This pull request fixes an error when parsing non-UTF8 charsets in quoted strings as per #177 (by default the fix returns the strings as binaries that are not necessarily valid UTF-8)

This pull request also adds an option to the parser that takes a charset_handler/2 function that receives the charset and binary and is expected to return the binary with the charset translated, by default it is `fn (_charset, binary) -> binary end`
