### PR TITLE
Failing test for parsing error on mail subject with many newlines

### DIFF
--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -817,6 +817,201 @@ defmodule Mail.Parsers.RFC2822Test do
     assert message.headers["content-type"] == ["text/html", {"charset", "us-ascii"}]
   end
 
+  # Yet another email found in the wild
+  test "parses all headers when lots of newlines" do
+    message =
+      parse_email("""
+      Delivered-To: user@exemple.com
+      MIME-Version: 1.0
+      Reply-To: Example Sender <sc-noreply@example.com>
+      Subject:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+      Your Subject
+      With So Much Newlines
+      From: Example Sender <sc-noreply@example.com>
+      To: user@example.com
+      Content-Type: multipart/alternative; boundary="0000000000003a77cb0623f1bbba"
+
+      """)
+    assert message.headers["from"] == "Example Sender <sc-noreply@example.com>"
+    assert message.headers["to"] == ["user@example.com"]
+  end
+
   defp parse_email(email),
     do: email |> convert_crlf |> Mail.Parsers.RFC2822.parse()
 


### PR DESCRIPTION
<!--
Thank you for contributing!

Here are a few things that will increase the chance that your pull request will get accepted:
 - Write tests, preferably in a test driven style.
 - Add documentation for the changes you made.
 - Follow our styleguide: https://github.com/dockyard/styleguides
-->

<!-- If this pull request addresses an issue please provide the issue number here -->
Closes # .

## Changes proposed in this pull request
Failing test inspired from an actual email, where lots of newlines in the subject header seem to prevent the headers after the one with those newlines to parsed.