### PR TITLE
Encode period at start of line

### DIFF
--- a/lib/mail/encoders/quoted_printable.ex
+++ b/lib/mail/encoders/quoted_printable.ex
@@ -8,7 +8,7 @@ defmodule Mail.Encoders.QuotedPrintable do
 
   @new_line "=\r\n"
   @max_length 76
-  @reserved_chars [?=, ??, ?_]
+  @reserved_chars [?=, ??, ?_, ?.]
 
   @doc """
   Encodes a string into a quoted-printable encoded string.
@@ -52,6 +52,21 @@ defmodule Mail.Encoders.QuotedPrintable do
       else
         encode(tail, max_length, acc <> @new_line <> escaped, byte_size(escaped))
       end
+    end
+  end
+
+  # Encode ASCII period character
+  def encode(<<char, tail::binary>>, max_length, acc, line_length) when char in [?.] do
+    escaped = "=" <> Base.encode16(<<char>>)
+    line_length = line_length + byte_size(<<char>>)
+
+    case line_length do
+      1 ->
+        encode(tail, max_length, acc <> escaped, byte_size(escaped))
+      x when x < max_length ->
+        encode(tail, max_length, acc <> <<char>>, line_length)
+      _ ->
+        encode(tail, max_length, acc <> @new_line <> escaped, byte_size(escaped))
     end
   end
 

--- a/test/mail/encoders/quoted_printable_test.exs
+++ b/test/mail/encoders/quoted_printable_test.exs
@@ -146,6 +146,42 @@ defmodule Mail.Encoders.QuotedPrintableTest do
     assert Mail.Encoders.QuotedPrintable.encode(message) == encoding
   end
 
+  test "encodes line beginning with a period" do
+    message = ".xxx"
+
+    encoding =
+      "=2Exxx"
+
+    assert Mail.Encoders.QuotedPrintable.encode(message) == encoding
+  end
+
+  test "encodes 75 chars ending with a period" do
+    message = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx."
+
+    encoding =
+      "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx."
+
+    assert Mail.Encoders.QuotedPrintable.encode(message) == encoding
+  end
+
+  test "encodes 76 chars ending with a period" do
+    message = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx."
+
+    encoding =
+      "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx=\r\n=2E"
+
+    assert Mail.Encoders.QuotedPrintable.encode(message) == encoding
+  end
+
+  test "encodes 77 chars ending with a period" do
+    message = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx."
+
+    encoding =
+      "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx=\r\nx."
+
+    assert Mail.Encoders.QuotedPrintable.encode(message) == encoding
+  end
+
   test "decodes empty string" do
     assert Mail.Encoders.QuotedPrintable.decode("") == ""
   end


### PR DESCRIPTION
For some reason I don't quite understand, a period at the beginning of a line is special.
Other email clients don't encode periods unless they are at the start of a line, so that's the example I followed here.

I'm not sure if it's possible for a period to be at the beginning of a line without being wrapped there, but I checked for that just in case.

I found this bug because it was deleting a period from a URL, breaking a link.

P.S. I'm new to Elixir so I welcome your correction