### PR TITLE
Fix get_html to support content-type with additional parameters

### DIFF
--- a/lib/mail.ex
+++ b/lib/mail.ex
@@ -95,10 +95,11 @@ defmodule Mail do
     end)
   end
 
-  def get_text(%Mail.Message{headers: %{"content-type" => ["text/plain" | _]}} = message),
-    do: message
-
-  def get_text(%Mail.Message{}), do: nil
+  def get_text(%Mail.Message{} = message) do
+    if Mail.Message.match_content_type?(message, "text/plain") do
+      message
+    end
+  end
 
   @doc """
   Add an HTML part to the message
@@ -156,12 +157,11 @@ defmodule Mail do
     end)
   end
 
-  def get_html(%Mail.Message{headers: %{"content-type" => "text/html"}} = message), do: message
-
-  def get_html(%Mail.Message{headers: %{"content-type" => ["text/html", _]}} = message),
-    do: message
-
-  def get_html(%Mail.Message{}), do: nil
+  def get_html(%Mail.Message{} = message) do
+    if Mail.Message.match_content_type?(message, "text/html") do
+      message
+    end
+  end
 
   defp default_charset do
     "UTF-8"

--- a/test/mail_test.exs
+++ b/test/mail_test.exs
@@ -305,6 +305,20 @@ defmodule MailTest do
     assert html_part.body == "<h1>Some HTML</h1>"
   end
 
+  test "get_html with content-type containing multiple parameters" do
+    html_part =
+      Mail.build()
+      |> Mail.Message.put_content_type(["text/html", {"charset", "UTF-8"}, {"format", "flowed"}])
+      |> Mail.Message.put_header(:content_transfer_encoding, :"8bit")
+      |> Mail.Message.put_body("<h1>Test body</h1>")
+
+    mail =
+      Mail.build_multipart()
+      |> Mail.Message.put_part(html_part)
+
+    assert Mail.get_html(mail).body == "<h1>Test body</h1>"
+  end
+
   test "get_html with nested multiparts without html" do
     inner_multipart =
       Mail.build_multipart()


### PR DESCRIPTION
Hi hello,  

I noticed a bug where `Mail.get_html/1` returns `nil` for certain emails when the `Content-Type` header includes additional parameters.

Here’s an example input extracted from a test email originally sent via Gmail:  

```  
------sinikael-?=_2-17332638766110.3058797854721649  
Content-Type: multipart/related;  
 boundary="----sinikael-?=_3-17332638766110.014999768033357563"  

------sinikael-?=_3-17332638766110.014999768033357563  
Content-Type: text/html; charset=utf-8; format=flowed  
Content-Transfer-Encoding: 7bit  

<html><head></head><body>...  
```

Bug occurs because of additional `format=flowed` parameter in `Content-Type`. Current implementation doesn't handle such cases because of too strict pattern match `["text/html", _]`.  

I initially considered resolving this with a small change to the pattern, but I discovered that the `match_content_type?/2` already provides a more robust way to handle `Content-Type` and took one extra step to refactor both `get_html` and `get_text`.

Let me know if this is okay for you, I can undo or make other adjustments based on your feedback.


---

Here is relevant specification from RFC [1341](https://www.rfc-editor.org/rfc/rfc1341) (MIME):  

```  
Content-Type := type "/" subtype *[";" parameter]  
```

---

Thank you for maintaining this library, cheers 🍻 
