### PR TITLE
parsing invalid header takes infinite time

### DIFF
--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -817,6 +817,15 @@ defmodule Mail.Parsers.RFC2822Test do
     assert message.headers["content-type"] == ["text/html", {"charset", "us-ascii"}]
   end
 
+  test "invalid content-type should not take infinite time" do
+    message =
+      parse_email("""
+      Content-type: text/html; charset=us-ascii;a
+      """)
+
+    assert message.headers["content-type"] == ["text/html", {"charset", "us-ascii"}]
+  end
+
   defp parse_email(email),
     do: email |> convert_crlf |> Mail.Parsers.RFC2822.parse()
 


### PR DESCRIPTION
<!--
Thank you for contributing!

Here are a few things that will increase the chance that your pull request will get accepted:
 - Write tests, preferably in a test driven style.
 - Add documentation for the changes you made.
 - Follow our styleguide: https://github.com/dockyard/styleguides
-->

<!-- If this pull request addresses an issue please provide the issue number here -->

## Changes proposed in this pull request
While investigating parsing issues occurring in production, I noticed that an invalid header containing an extra character after the charset semicolon causes the parsing process to hang indefinitely.
Even though it did not happen to us in production, I thought it was worth bringing that to your attention.