### PR TITLE
Encode name in address if necessary

### DIFF
--- a/lib/mail/renderers/rfc_2822.ex
+++ b/lib/mail/renderers/rfc_2822.ex
@@ -138,7 +138,7 @@ defmodule Mail.Renderers.RFC2822 do
     end
   end
 
-  defp render_address({name, email}), do: ~s("#{name}" <#{validate_address(email)}>)
+  defp render_address({name, email}), do: "#{encode_header_value(~s("#{name}"), :quoted_printable)} <#{validate_address(email)}>"
   defp render_address(email), do: validate_address(email)
   defp render_subtypes([]), do: []
 

--- a/test/mail/message_test.exs
+++ b/test/mail/message_test.exs
@@ -231,13 +231,30 @@ defmodule Mail.MessageTest do
     assert %Mail.Message{headers: %{"subject" => ^subject}} = Mail.Parsers.RFC2822.parse(txt)
   end
 
-  test "UTF-8 in subject (quoted printable with spaces, RFC 2047§4.2 (2)" do
+  test "UTF-8 in subject (quoted printable with spaces, RFC 2047§4.2 (2))" do
     subject = "test 😀 test"
 
     mail =
       "Subject: =?UTF-8?Q?test_" <> Mail.Encoders.QuotedPrintable.encode("😀") <> "_test?=\r\n\r\n"
 
     assert %Mail.Message{headers: %{"subject" => ^subject}} = Mail.Parsers.RFC2822.parse(mail)
+  end
+
+  test "UTF-8 in addresses" do
+    from = {"Joachim Löw", "joachim.loew@example.com"}
+    to = {"Wolfgang Schüler", "wolfgang.schueler@example.com"}
+
+    txt =
+      Mail.build()
+      |> Mail.put_from(from)
+      |> Mail.put_to(to)
+      |> Mail.render()
+
+    encoded_from = ~s(From: =?UTF-8?Q?"#{Mail.Encoders.QuotedPrintable.encode(elem(from, 0))}"?= <#{elem(from, 1)}>)
+    encoded_to = ~s(To: =?UTF-8?Q?"#{Mail.Encoders.QuotedPrintable.encode(elem(to, 0))}"?= <#{elem(to, 1)}>)
+
+    assert txt =~ encoded_from
+    assert txt =~ encoded_to
   end
 
   test "UTF-8 in other header" do


### PR DESCRIPTION
## Changes proposed in this pull request
Currently address fields like from, to, cc and so on do not encode the name in the address, which causes problems on older email clients. This PR encods the name in the address if necessary. 