### PR TITLE
Wrap header values in quotes if they contain characters that are not allowed

### DIFF
--- a/lib/mail/renderers/rfc_2822.ex
+++ b/lib/mail/renderers/rfc_2822.ex
@@ -155,7 +155,7 @@ defmodule Mail.Renderers.RFC2822 do
     value = encode_header_value(value, :quoted_printable)
 
     value =
-      if value =~ ~r/[\s;]/ do
+      if value =~ ~r/[\s()<>@,;:\\<\/\[\]?=]/ do
         "\"#{value}\""
       else
         value

--- a/lib/mail/renderers/rfc_2822.ex
+++ b/lib/mail/renderers/rfc_2822.ex
@@ -140,6 +140,7 @@ defmodule Mail.Renderers.RFC2822 do
 
   defp render_address({name, email}), do: ~s("#{name}" <#{validate_address(email)}>)
   defp render_address(email), do: validate_address(email)
+
   defp render_subtypes([]), do: []
 
   defp render_subtypes([{key, value} | subtypes]) when is_atom(key),
@@ -152,6 +153,14 @@ defmodule Mail.Renderers.RFC2822 do
   defp render_subtypes([{key, value} | subtypes]) do
     key = String.replace(key, "_", "-")
     value = encode_header_value(value, :quoted_printable)
+
+    value =
+      if value =~ ~r/[\s;]/ do
+        "\"#{value}\""
+      else
+        value
+      end
+
     ["#{key}=#{value}" | render_subtypes(subtypes)]
   end
 

--- a/test/mail/renderers/rfc_2822_test.exs
+++ b/test/mail/renderers/rfc_2822_test.exs
@@ -15,6 +15,17 @@ defmodule Mail.Renderers.RFC2822Test do
     assert header == "Foo-Bar: abcd; baz-buzz=qux"
   end
 
+  test "quotes header parameters if necessary" do
+    header = Mail.Renderers.RFC2822.render_header("Content-Disposition", ["attachment", filename: "my-test-file"])
+    assert header == "Content-Disposition: attachment; filename=my-test-file"
+
+    header = Mail.Renderers.RFC2822.render_header("Content-Disposition", ["attachment", filename: "my test file"])
+    assert header == "Content-Disposition: attachment; filename=\"my test file\""
+
+    header = Mail.Renderers.RFC2822.render_header("Content-Disposition", ["attachment", filename: "my;test;file"])
+    assert header == "Content-Disposition: attachment; filename=\"my;test;file\""
+  end
+
   test "address headers renders list of recipients" do
     header = Mail.Renderers.RFC2822.render_header("from", "user1@example.com")
     assert header == "From: user1@example.com"


### PR DESCRIPTION
## Changes proposed in this pull request
This PR adds quotes around header parameters if necessary. This resolves an issue where attachments with spaces in their file names would not be displayed correctly, due to the client thinking not parsing the rest of the name after the space