### PR TITLE
failure to parse recipient value when the name is an e-mail address containing additional quotes

### DIFF
--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -570,6 +570,19 @@ defmodule Mail.Parsers.RFC2822Test do
     assert message.headers["from"] == {"Lastname, First Names", "me@example.com"}
   end
 
+  test "address name is an e-mail address with additiongal quotes" do
+    message =
+      parse_email("""
+      To: "User, Test" <user@example.com>
+      From: ""me@example.com"" <me@example.com>
+      Date: Fri, 1 Jan 2016 00:00:00 +0000
+      Subject: Blank body
+
+      """)
+
+    assert message.headers["from"] == {"\"me@example.com\"", "me@example.com"}
+  end
+
   # See https://tools.ietf.org/html/rfc2047
   test "parses headers with encoded word syntax" do
     message =


### PR DESCRIPTION


Found in production: an e-mail has the 'from' field with the following value:
```ex
""service@service.com" " <service@service.com>
````

which is incorrectly parsed into `service@service.com\"` instead of
```ex
{"\"service@service.com\"", "service@service.com"}
````

## Changes proposed in this pull request
- Add test for reproducing the issue