### PR TITLE
Update regular expression for parsing recipient values

### DIFF
--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -570,6 +570,19 @@ defmodule Mail.Parsers.RFC2822Test do
     assert message.headers["from"] == {"Lastname, First Names", "me@example.com"}
   end
 
+  test "address name is an e-mail address with additiongal quotes" do
+    message =
+      parse_email("""
+      To: "User, Test" <user@example.com>
+      From: ""me@example.com"" <me@example.com>
+      Date: Fri, 1 Jan 2016 00:00:00 +0000
+      Subject: Blank body
+
+      """)
+
+    assert message.headers["from"] == {"\"me@example.com\"", "me@example.com"}
+  end
+
   # See https://tools.ietf.org/html/rfc2047
   test "parses headers with encoded word syntax" do
     message =


### PR DESCRIPTION
I’ve broken the regular expression to match three distinct types of address

1. Quoted name with address
2. Non-quoted name with address
3. address on it’s own

I have also changed to expanded notation to make it a little clearer.

This provides a fix for #191 

NOTE: This still does not correctly parse all valid address spec values. It won’t handle comments or group syntax to name two I can immediately think of. To solve that, we’ll need a proper address spec parser