### PR TITLE
Handle invalid datetime with a space before the comma

### DIFF
--- a/lib/mail/parsers/rfc_2822.ex
+++ b/lib/mail/parsers/rfc_2822.ex
@@ -95,6 +95,9 @@ defmodule Mail.Parsers.RFC2822 do
   defp parse_datetime(<<"\t", rest::binary>>), do: parse_datetime(rest)
   defp parse_datetime(<<_day::binary-size(3), ", ", rest::binary>>), do: parse_datetime(rest)
 
+  # Handle day name with space before comma: "Fri , 18 Apr 2025 05:50:01 +0200"
+  defp parse_datetime(<<_day::binary-size(3), " ", ",", rest::binary>>), do: parse_datetime(rest)
+
   defp parse_datetime(<<date::binary-size(1), " ", rest::binary>>),
     do: parse_datetime("0" <> date <> " " <> rest)
 

--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -210,6 +210,7 @@ defmodule Mail.Parsers.RFC2822Test do
     import Mail.Parsers.RFC2822, only: [to_datetime: 1]
 
     assert to_datetime("Fri, 1 Jan 2016 00:00:00 +0000") == ~U"2016-01-01 00:00:00Z"
+    assert to_datetime("Fri , 18 Apr 2025 05:50:01 +0200") == ~U"2025-04-18 03:50:01Z"
     assert to_datetime("1 Feb 2016 01:02:03 +0000") == ~U"2016-02-01 01:02:03Z"
     assert to_datetime(" 1 Mar 2016 11:12:13 +0000") == ~U"2016-03-01 11:12:13Z"
     assert to_datetime("\t1 Apr 2016 22:33:44 +0000") == ~U"2016-04-01 22:33:44Z"


### PR DESCRIPTION
Hello, 

We found this case in production.
I see there is already a few invalid edge-cases so I figure it might be good to support this as well. 
