### PR TITLE
Handle attachments without name in content-type header

### DIFF
--- a/lib/mail/parsers/rfc_2822.ex
+++ b/lib/mail/parsers/rfc_2822.ex
@@ -430,6 +430,7 @@ defmodule Mail.Parsers.RFC2822 do
 
   defp parse_header_value("content-type", value) do
     case parse_structured_header_value(value) do
+      [header] -> [header, {"charset", "us-ascii"}]
       [_ | _] = header -> header
       <<value::binary>> -> [value, {"charset", "us-ascii"}]
     end


### PR DESCRIPTION
The case was encountered in production.

Fixes the error below for emls without a `name` property in the `Content-Type` header:
e.g.:
```
Content-Type: application/pdf;
Content-Transfer-Encoding: base64
Content-Disposition: attachment; filename="20250410-1947.pdf"
```


The error:
```
     The following arguments were given to Mail.Parsers.RFC2822.parse_encoded_word/2:

         # 1
         ["application/pdf"]

         # 2
         []

     Attempted function clauses (showing 3 out of 3):
         defp parse_encoded_word("", _opts)
         defp parse_encoded_word(<<"=?", value::binary>>, opts)
         defp parse_encoded_word(<<char::utf8, rest::binary>>, opts)
```