### PR TITLE
add failing test for custom headers in multipart message

### DIFF
--- a/lib/mail/renderers/rfc_2822.ex
+++ b/lib/mail/renderers/rfc_2822.ex
@@ -32,10 +32,12 @@ defmodule Mail.Renderers.RFC2822 do
   Renders a message according to the RFC2822 spec
   """
   def render(%Mail.Message{multipart: true} = message) do
-    message
-    |> reorganize
-    |> Mail.Message.put_header(:mime_version, "1.0")
-    |> render_part()
+    part =
+      message
+      |> reorganize
+      |> Mail.Message.put_header(:mime_version, "1.0")
+
+    render_part(%{part | headers: Map.merge(message.headers, part.headers)})
   end
 
   def render(%Mail.Message{} = message),


### PR DESCRIPTION
Hi,

Following this commit https://github.com/DockYard/elixir-mail/commit/f738af707421f6b40358b70e1f6c0bfe6bf6ff39, we encounter an issue: when rendering a multi-part message, the headers are missing. 

This PR adds 2 tests to showcase the problem:
1. The first test uses a single-part message and succeeds
2. The second test uses a multi-part message and fails (no headers except for the `mime-version` are present)

I've attempted a fix in lib/mail/renderers/rfc_2822.ex although I'm unsure if it's the best way to approach the problem.

