### PR TITLE
Handle multipart content-type with no parts

### DIFF
--- a/lib/mail/parsers/rfc_2822.ex
+++ b/lib/mail/parsers/rfc_2822.ex
@@ -665,7 +665,10 @@ defmodule Mail.Parsers.RFC2822 do
         parse(part, opts)
       end)
 
-    Map.put(message, :parts, parts)
+    case parts do
+      [] -> parse_body(Map.put(message, :multipart, false), lines, opts)
+      _ -> Map.put(message, :parts, parts)
+    end
   end
 
   defp parse_body(%Mail.Message{} = message, [], _opts) do

--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -967,7 +967,23 @@ defmodule Mail.Parsers.RFC2822Test do
       """)
 
     assert message.parts == []
-    assert message.body == nil
+    assert message.body == ""
+  end
+
+  test "multipart content-type with no parts" do
+    message =
+      parse_email("""
+      To: user@example.com
+      From: me@example.com
+      Subject: Test
+      Content-Type: multipart/mixed; boundary="foobar"
+
+      This is a message with multipart content-type but no actual parts
+      """)
+
+    assert message.headers["content-type"] == ["multipart/mixed", {"boundary", "foobar"}]
+    assert message.body == "This is a message with multipart content-type but no actual parts"
+    assert message.parts == []
   end
 
   test "content-type with explicit charset" do


### PR DESCRIPTION
Fix parsing of emails that have multipart content-type headers but no actual parts in the body
Previously these would fail to parse correctly. Now they are treated as regular single-part messages with the body content preserved.
