### PR TITLE
Support parameter continuations for filename

### DIFF
--- a/lib/mail/parsers/rfc_2822.ex
+++ b/lib/mail/parsers/rfc_2822.ex
@@ -530,10 +530,12 @@ defmodule Mail.Parsers.RFC2822 do
 
   defp parse_structured_header_value("", value, [{key, nil} | sub_types], _part, acc) do
     [value | Enum.reverse([{key, acc} | sub_types])]
+    |> assemble_params()
   end
 
   defp parse_structured_header_value("", value, sub_types, :param_name, _acc) do
     [value | Enum.reverse(sub_types)]
+    |> assemble_params()
   end
 
   defp parse_structured_header_value("", nil, [], _part, acc) do
@@ -542,6 +544,7 @@ defmodule Mail.Parsers.RFC2822 do
 
   defp parse_structured_header_value("", value, [_ | _] = sub_types, _part, "") do
     [value | Enum.reverse(sub_types)]
+    |> assemble_params()
   end
 
   defp parse_structured_header_value("", value, [], _part, acc) do
@@ -716,6 +719,67 @@ defmodule Mail.Parsers.RFC2822 do
     |> String.trim()
     |> String.downcase()
     |> String.replace("-", "_")
+  end
+
+  defp assemble_params(params) when is_list(params) do
+    {regular_params, continued_params} =
+      params
+      |> Enum.split_with(fn
+        {key, _value} when is_binary(key) ->
+          not String.match?(key, ~r/\*\d+\*?$/)
+
+        _ ->
+          true
+      end)
+
+    reassembled =
+      continued_params
+      |> Enum.group_by(fn {key, _value} ->
+        String.replace(key, ~r/\*\d+\*?$/, "")
+      end)
+      |> Enum.map(&reassemble_param_group/1)
+
+    regular_params ++ reassembled
+  end
+
+  defp reassemble_param_group({base_name, continuations}) do
+    sorted_continuations =
+      continuations
+      |> Enum.sort_by(fn {key, _value} ->
+        case Regex.run(~r/\*(\d+)\*?$/, key) do
+          [_, num] -> String.to_integer(num)
+          _ -> 0
+        end
+      end)
+
+    is_encoded =
+      sorted_continuations
+      |> List.first()
+      |> elem(0)
+      |> String.ends_with?("*")
+
+    combined_value =
+      sorted_continuations
+      |> Enum.map(fn {_key, value} -> value end)
+      |> handle_sorted_continuations(is_encoded)
+
+    {base_name, combined_value}
+  end
+
+  defp handle_sorted_continuations(list, false), do: list |> Enum.join("")
+
+  defp handle_sorted_continuations([first | rest], true) do
+    {_charset, _lang, first_value} =
+      case String.split(first, "'", parts: 3) do
+        [charset, lang, encoded_value] ->
+          {charset, lang, encoded_value}
+
+        _ ->
+          {"UTF-8", "", first}
+      end
+
+    Enum.join([first_value | rest], "")
+    |> URI.decode()
   end
 
   defp multipart?(headers) do

--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -1085,6 +1085,83 @@ defmodule Mail.Parsers.RFC2822Test do
     assert message.headers["content-type"] == ["text/html", {"charset", "us-ascii"}]
   end
 
+  test "parses RFC 2231 parameter continuations for long filenames" do
+    message =
+      parse_email("""
+      Subject: RFC 2231 Long filename test
+      Content-Type: multipart/mixed; boundary="boundary123"
+
+      --boundary123
+      Content-Type: application/pdf
+      Content-Disposition: attachment;
+        filename*0="a_very_long_filename_that_needs_to_be_split_across_multiple_";
+        filename*1="lines_according_to_RFC_2231_parameter_continuations.pdf"
+
+      PDF content here
+      --boundary123--
+      """)
+
+    [part] = message.parts
+
+    assert [
+             "attachment",
+             {"filename",
+              "a_very_long_filename_that_needs_to_be_split_across_multiple_lines_according_to_RFC_2231_parameter_continuations.pdf"}
+           ] =
+             part.headers["content-disposition"]
+  end
+
+  test "parses RFC 2231 parameter continuations with charset and language" do
+    message =
+      parse_email("""
+      Subject: RFC 2231 with charset
+      Content-Type: multipart/mixed; boundary="boundary456"
+
+      --boundary456
+      Content-Type: image/png
+      Content-Disposition: inline;
+        filename*0*=UTF-8'en'%C3%A9%C3%A0%20test%20file%20with%20special%20;
+        filename*1*=characters%20%C3%B1%C3%B6%C3%BC.png
+
+      PNG content here
+      --boundary456--
+      """)
+
+    [part] = message.parts
+
+    assert ["inline", {"filename", "éà test file with special characters ñöü.png"}] =
+             part.headers["content-disposition"]
+  end
+
+  test "parses mixed RFC 2231 continuations with regular parameters" do
+    message =
+      parse_email("""
+      Subject: RFC 2231 mixed parameters
+      Content-Type: multipart/mixed; boundary="boundary789"
+
+      --boundary789
+      Content-Type: application/octet-stream;
+        name="short.txt"
+      Content-Disposition: attachment;
+        filename*0="this_is_a_very_long_filename_that_exceeds_the_";
+        filename*1="normal_line_length_limit_";
+        filename*2="and_needs_to_be_continued.txt";
+        size="12345"
+
+      File content here
+      --boundary789--
+      """)
+
+    [part] = message.parts
+    ["attachment" | params] = part.headers["content-disposition"]
+
+    assert {"filename",
+            "this_is_a_very_long_filename_that_exceeds_the_normal_line_length_limit_and_needs_to_be_continued.txt"} in params
+
+    assert {"size", "12345"} in params
+    assert length(params) == 2
+  end
+
   defp parse_email(email, opts \\ []),
     do: email |> convert_crlf |> Mail.Parsers.RFC2822.parse(opts)
 


### PR DESCRIPTION
## Changes proposed in this pull request

Files with very long names will be encoded across multiple lines by email clients and this PR makes it possible to parse those emails and get the correct filenames for those attachments. These are called “parameter continuations” I think. I tried to be as surgical as possible.

🫡 
