### PR TITLE
Handle content-disposition with trailing semicolon (fixes #212)

### DIFF
--- a/lib/mail/parsers/rfc_2822.ex
+++ b/lib/mail/parsers/rfc_2822.ex
@@ -393,7 +393,7 @@ defmodule Mail.Parsers.RFC2822 do
 
     value =
       case value do
-        [value | params] = list when is_binary(value) and is_list(params) ->
+        [value | params] = list when is_binary(value) ->
           if is_params(params) do
             [value | concatenate_continuation_params(params, opts)]
           else
@@ -462,8 +462,9 @@ defmodule Mail.Parsers.RFC2822 do
     end
   end
 
-  defp parse_header_value("content-disposition", value),
-    do: parse_structured_header_value(value)
+  defp parse_header_value("content-disposition", value) do
+    List.wrap(parse_structured_header_value(value))
+  end
 
   defp parse_header_value(_key, value),
     do: value
@@ -504,6 +505,10 @@ defmodule Mail.Parsers.RFC2822 do
     decoded = parse_encoded_word(value, opts)
     params = Enum.map(params, fn {param, value} -> {param, parse_encoded_word(value, opts)} end)
     [decoded | params]
+  end
+
+  defp decode_header_value(_key, value, _opts) when is_list(value) do
+    value
   end
 
   defp decode_header_value(_key, {name, email}, opts) do

--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -1094,6 +1094,15 @@ defmodule Mail.Parsers.RFC2822Test do
     assert message.headers["content-type"] == ["text/html", {"charset", "us-ascii"}]
   end
 
+  test "content-disposition with trailing semicolon" do
+    message =
+      parse_email("""
+      Content-Disposition: inline;
+      """)
+
+    assert message.headers["content-disposition"] == ["inline"]
+  end
+
   describe "RFC 2231 parameter continuations" do
     test "parses parameter continuations for long filenames" do
       message =


### PR DESCRIPTION
Prevents parsing error when a content-disposition header ends with a semicolon and no params list