### PR TITLE
Fix spec and docs in Mail.Encoders.QuotedPrintable

### DIFF
--- a/lib/mail/encoders/quoted_printable.ex
+++ b/lib/mail/encoders/quoted_printable.ex
@@ -72,7 +72,7 @@ defmodule Mail.Encoders.QuotedPrintable do
 
   ## Examples
 
-      Mail.QuotedPrintable.decode("fa=C3=A7ade")
+      Mail.Encoders.QuotedPrintable.decode("fa=C3=A7ade")
       "façade"
   """
   @spec decode(binary) :: binary


### PR DESCRIPTION
cherry-picked changes from #209 that can be merged on their own

## Changes proposed in this pull request
 - fix the `@spec` to have the right type
 - fix module reference in doc
