### PR TITLE
Improve header encoding with folding

### DIFF
--- a/lib/mail/renderers/rfc_2822.ex
+++ b/lib/mail/renderers/rfc_2822.ex
@@ -134,9 +134,9 @@ defmodule Mail.Renderers.RFC2822 do
     |> Enum.join(" ")
   end
 
-  defp render_header_value(_key, [value | subtypes]),
+  defp render_header_value(key, [value | subtypes]),
     do:
-      Enum.join([encode_header_value(value, :quoted_printable) | render_subtypes(subtypes)], "; ")
+      Enum.join([encode_header_value(value, key) | render_subtypes(subtypes)], "; ")
 
   defp render_header_value(key, value),
     do: render_header_value(key, List.wrap(value))
@@ -155,7 +155,7 @@ defmodule Mail.Renderers.RFC2822 do
   end
 
   defp render_address({name, email}),
-    do: "#{encode_header_value(~s("#{name}"), :quoted_printable)} <#{validate_address(email)}>"
+    do: "#{encode_header_value(~s("#{name}"))} <#{validate_address(email)}>"
 
   defp render_address(email), do: validate_address(email)
 
@@ -170,7 +170,7 @@ defmodule Mail.Renderers.RFC2822 do
 
   defp render_subtypes([{key, value} | subtypes]) do
     key = String.replace(key, "_", "-")
-    value = encode_header_value(value, :quoted_printable)
+    value = encode_header_value(value)
 
     value =
       if value =~ ~r/[\s()<>@,;:\\<\/\[\]?=]/ do
@@ -204,16 +204,39 @@ defmodule Mail.Renderers.RFC2822 do
     |> Enum.join("\r\n")
   end
 
-  # As stated at https://datatracker.ietf.org/doc/html/rfc2047#section-2, encoded words must be
-  # split in 76 chars including its surroundings and delimmiters.
-  # Since enclosing starts with =?UTF-8?Q? and ends with ?=, max length should be 64
-  # Per RFC 2047, encoding is only required for non-ASCII characters.
-  # ASCII-only headers should not be encoded, regardless of length.
-  # Per RFC 2047, ASCII-only headers should not be encoded, regardless of length
-  defp encode_header_value(header_value, :quoted_printable) do
+  defp encode_header_value(header_value, header \\ "") do
     if contains_non_ascii?(header_value) do
-      header_value |> Mail.Encoders.QuotedPrintable.encode(64) |> wrap_encoded_words()
+      # From RFC2047 §2 https://datatracker.ietf.org/doc/html/rfc2047#section-2
+      # An 'encoded-word' may not be more than 75 characters long, including
+      # 'charset', 'encoding', 'encoded-text', and delimiters.  If it is
+      # desirable to encode more text than will fit in an 'encoded-word' of
+      # 75 characters, multiple 'encoded-word's (separated by CRLF SPACE) may
+      # be used.
+
+      # From RFC2047 §5 https://datatracker.ietf.org/doc/html/rfc2047#section-5
+      # ... an 'encoded-word' that appears in a
+      # header field defined as '*text' MUST be separated from any adjacent
+      # 'encoded-word' or 'text' by 'linear-white-space'.
+
+      header_value
+      |> Mail.Encoders.QuotedPrintable.encode(
+        # 75 is maximum length, subtract wrapping, add trailing "=" we strip out
+        75 - byte_size("=?UTF-8?Q?") - byte_size("?=") + byte_size("="),
+        <<>>,
+        byte_size(header) + byte_size(": ")
+      )
+      |> :binary.split("=\r\n", [:global])
+      |> Enum.map(fn chunk ->
+        # SPACE must be encoded as "_" and then everything wrapped
+        # to indicate an 'encoded-word'
+        chunk = String.replace(chunk, " ", "_")
+        <<"=?UTF-8?Q?", chunk::binary, "?=">>
+      end)
+      |> Enum.join(" ")
     else
+      # Per RFC 2047, encoding is only required for non-ASCII characters.
+      # ASCII-only headers should not be encoded, regardless of length.
+      # Per RFC 2047, ASCII-only headers should not be encoded, regardless of length
       header_value
     end
   end
@@ -222,12 +245,6 @@ defmodule Mail.Renderers.RFC2822 do
   defp contains_non_ascii?(<<>>), do: false
   defp contains_non_ascii?(<<byte, _rest::binary>>) when byte > 127, do: true
   defp contains_non_ascii?(<<_byte, rest::binary>>), do: contains_non_ascii?(rest)
-
-  defp wrap_encoded_words(value) do
-    :binary.split(value, "=\r\n", [:global])
-    |> Enum.map(fn chunk -> <<"=?UTF-8?Q?", chunk::binary, "?=">> end)
-    |> Enum.join()
-  end
 
   @doc """
   Builds a RFC2822 timestamp from an Erlang timestamp


### PR DESCRIPTION
rebased replacement of #209

## Changes proposed in this pull request
We should fold content to try to keep within 78 characters per line (excluding CRLF).  This PR keeps ASCII as ASCII, but folds at foldable whitespace.  Also, reworks encoding-words to properly encoding spaces as `"_"` and to leave foldable space between blocks.

 - restructured `encode_header_value`:
   - to drop `:quoted_printable` and accept the header name (to help support folding on first line)
   - if encoding is needed:
     - put into blocks of up to 75 characters with space between to allow folding (previously all the encoding blocks were just put together with no space or CRLF between them)
     - make spaces into `_` to prevent folding within an encoded word (and to follow the RFC)
 - do "folding" as a follow-up step as it quickly becomes confusing with email address fields that _should_ be folded after commas and not just on any space
   - currently only does folding on "other" fields that aren't matched by more specific `render_header_value/2` functions

I reviewed folding for DKIM headers, and I believe this handles those properly as it also requires folding on "foldable whitespace"
