### PR TITLE
Update parsing of recipients

### DIFF
--- a/lib/mail/parsers/rfc_2822.ex
+++ b/lib/mail/parsers/rfc_2822.ex
@@ -18,7 +18,7 @@ defmodule Mail.Parsers.RFC2822 do
       ...> It has more than one line\r
       ...> \"""
       iex> Mail.Parsers.RFC2822.parse(message)
-      %Mail.Message{body: "This is the body!\r\nIt has more than one line", headers: %{"to" => ["user@example.com"], "from" => "me@example.com", "subject" => "Test Email", "content-type" => ["text/plain", {"foo", "bar"}, {"baz", "qux"}]}}
+      %Mail.Message{body: "This is the body!\r\nIt has more than one line", headers: %{"to" => ["user@example.com"], "from" => ["me@example.com"], "subject" => "Test Email", "content-type" => ["text/plain", {"foo", "bar"}, {"baz", "qux"}]}}
   """
 
   @months ~w(jan feb mar apr may jun jul aug sep oct nov dec)
@@ -440,14 +440,10 @@ defmodule Mail.Parsers.RFC2822 do
     do: parse_recipient_value(value)
 
   defp parse_header_value("from", value),
-    do:
-      parse_recipient_value(value)
-      |> List.first()
+    do: parse_recipient_value(value)
 
   defp parse_header_value("reply-to", value),
-    do:
-      parse_recipient_value(value)
-      |> List.first()
+    do: parse_recipient_value(value)
 
   defp parse_header_value("date", timestamp),
     do: to_datetime(timestamp)
@@ -490,12 +486,8 @@ defmodule Mail.Parsers.RFC2822 do
     addresses
   end
 
-  defp decode_header_value("from", {_name, _address} = value, opts) do
-    [from] = decode_header_value("from", [value], opts)
-    from
   end
 
-  defp decode_header_value("from", value, _opts), do: value
 
   defp decode_header_value("received", value, _opts),
     do: value

--- a/lib/mail/parsers/rfc_2822.ex
+++ b/lib/mail/parsers/rfc_2822.ex
@@ -439,6 +439,9 @@ defmodule Mail.Parsers.RFC2822 do
   defp parse_header_value("cc", value),
     do: parse_recipient_value(value)
 
+  defp parse_header_value("bcc", value),
+    do: parse_recipient_value(value)
+
   defp parse_header_value("from", value),
     do: parse_recipient_value(value)
 
@@ -472,7 +475,7 @@ defmodule Mail.Parsers.RFC2822 do
     do: datetime
 
   defp decode_header_value(key, addresses, opts)
-       when key in ["to", "cc", "from", "reply-to"] and is_list(addresses) do
+       when key in ["to", "cc", "bcc", "from", "reply-to"] and is_list(addresses) do
     addresses =
       Enum.map(addresses, fn
         {name, email} ->

--- a/lib/mail/parsers/rfc_2822.ex
+++ b/lib/mail/parsers/rfc_2822.ex
@@ -445,6 +445,11 @@ defmodule Mail.Parsers.RFC2822 do
   defp parse_header_value("from", value),
     do: parse_recipient_value(value)
 
+  # If present, the Sender header always contains only one recipient
+  # If not present, the Sender will be nil
+  defp parse_header_value("sender", value),
+    do: parse_recipient_value(value) |> List.first()
+
   defp parse_header_value("reply-to", value),
     do: parse_recipient_value(value)
 
@@ -475,7 +480,7 @@ defmodule Mail.Parsers.RFC2822 do
     do: datetime
 
   defp decode_header_value(key, addresses, opts)
-       when key in ["to", "cc", "bcc", "from", "reply-to"] and is_list(addresses) do
+       when key in ["to", "cc", "bcc", "from", "sender", "reply-to"] and is_list(addresses) do
     addresses =
       Enum.map(addresses, fn
         {name, email} ->
@@ -489,8 +494,12 @@ defmodule Mail.Parsers.RFC2822 do
     addresses
   end
 
+  defp decode_header_value("sender", {_name, _address} = value, opts) do
+    [sender] = decode_header_value("sender", [value], opts)
+    sender
   end
 
+  defp decode_header_value("sender", value, _opts), do: value
 
   defp decode_header_value("received", value, _opts),
     do: value

--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -45,6 +45,7 @@ defmodule Mail.Parsers.RFC2822Test do
       parse_email("""
       To: Test User <user@example.com>, Other User <other@example.com>
       CC: The Dude <dude@example.com>, Batman <batman@example.com>
+      BCC: Barbie <barbie@example.com>, Ken <ken@example.com>
       From: Me <me@example.com>
       Reply-To: OtherMe <otherme@example.com>
       Subject: Test email
@@ -71,6 +72,11 @@ defmodule Mail.Parsers.RFC2822Test do
     assert message.headers["cc"] == [
              {"The Dude", "dude@example.com"},
              {"Batman", "batman@example.com"}
+           ]
+
+    assert message.headers["bcc"] == [
+             {"Barbie", "barbie@example.com"},
+             {"Ken", "ken@example.com"}
            ]
 
     assert message.headers["from"] == [{"Me", "me@example.com"}]

--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -196,6 +196,27 @@ defmodule Mail.Parsers.RFC2822Test do
     assert Mail.get_html(message) == html_part2
   end
 
+  describe "parses a message with a sender" do
+    # The sender field, if present, can only contain a single recipient
+    test "single sender" do
+      message =
+        parse_email("""
+        Sender: "John Doe" <other@example.com>
+        """)
+
+      assert message.headers["sender"] == {"John Doe", "other@example.com"}
+    end
+
+    test "multiple senders return only the first sender" do
+      message =
+        parse_email("""
+        Sender: user@example.com, "John Doe" <other@example.com>
+        """)
+
+      assert message.headers["sender"] == "user@example.com"
+    end
+  end
+
   describe "parses a message with multiple recipients" do
     test "multiple recipients in To header" do
       # Multiple recipients where some have names can be interpreted as a header value with params if not handled correctly.

--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -17,8 +17,8 @@ defmodule Mail.Parsers.RFC2822Test do
       """)
 
     assert message.headers["to"] == ["user@example.com"]
-    assert message.headers["from"] == "me@example.com"
-    assert message.headers["reply-to"] == "otherme@example.com"
+    assert message.headers["from"] == ["me@example.com"]
+    assert message.headers["reply-to"] == ["otherme@example.com"]
     assert message.headers["subject"] == "Test Email"
     assert message.headers["content-type"] == ["text/plain", {"foo", "bar"}, {"baz", "qux"}]
     assert message.body == "This is the body!\r\nIt has more than one line"
@@ -34,8 +34,8 @@ defmodule Mail.Parsers.RFC2822Test do
       """)
 
     assert message.headers["to"] == ["user@example.com"]
-    assert message.headers["from"] == "me@example.com"
-    assert message.headers["reply-to"] == "otherme@example.com"
+    assert message.headers["from"] == ["me@example.com"]
+    assert message.headers["reply-to"] == ["otherme@example.com"]
     assert message.headers["subject"] == "Test Email"
     assert message.body == ""
   end
@@ -73,8 +73,8 @@ defmodule Mail.Parsers.RFC2822Test do
              {"Batman", "batman@example.com"}
            ]
 
-    assert message.headers["from"] == {"Me", "me@example.com"}
-    assert message.headers["reply-to"] == {"OtherMe", "otherme@example.com"}
+    assert message.headers["from"] == [{"Me", "me@example.com"}]
+    assert message.headers["reply-to"] == [{"OtherMe", "otherme@example.com"}]
     assert message.headers["content-type"] == ["multipart/alternative", {"boundary", "foobar"}]
 
     [text_part, html_part] = message.parts
@@ -190,18 +190,34 @@ defmodule Mail.Parsers.RFC2822Test do
     assert Mail.get_html(message) == html_part2
   end
 
-  test "parses a message with multiple recipients" do
-    # Multiple recipients where some have names can be interpreted as a header value with params if not handled correctly.
-    message =
-      parse_email("""
-      To: user@example.com, "John Doe" <other@example.com>, jane@example.com
-      """)
+  describe "parses a message with multiple recipients" do
+    test "multiple recipients in To header" do
+      # Multiple recipients where some have names can be interpreted as a header value with params if not handled correctly.
+      message =
+        parse_email("""
+        To: user@example.com, "John Doe" <other@example.com>, jane@example.com
+        """)
 
-    assert message.headers["to"] == [
-             "user@example.com",
-             {"John Doe", "other@example.com"},
-             "jane@example.com"
-           ]
+      assert message.headers["to"] == [
+               "user@example.com",
+               {"John Doe", "other@example.com"},
+               "jane@example.com"
+             ]
+    end
+
+    test "multiple recipients in From header" do
+      # Multiple recipients where some have names can be interpreted as a header value with params if not handled correctly.
+      message =
+        parse_email("""
+        From: user@example.com, "John Doe" <other@example.com>, jane@example.com
+        """)
+
+      assert message.headers["from"] == [
+               "user@example.com",
+               {"John Doe", "other@example.com"},
+               "jane@example.com"
+             ]
+    end
   end
 
   test "to_datetime/1" do
@@ -399,7 +415,7 @@ defmodule Mail.Parsers.RFC2822Test do
              {"Batman", "batman@example.com"}
            ]
 
-    assert message.headers["from"] == {"Me", "me@example.com"}
+    assert message.headers["from"] == [{"Me", "me@example.com"}]
     assert message.headers["content-type"] == ["multipart/mixed", {"boundary", "foobar"}]
     assert message.headers["date"] == ~U"2016-01-01 00:00:00Z"
 
@@ -572,7 +588,7 @@ defmodule Mail.Parsers.RFC2822Test do
 
     assert message.headers["to"] == [{"Test User", "user@example.com"}]
     assert message.headers["cc"] == ["other@example.com"]
-    assert message.headers["from"] == "me@example.com"
+    assert message.headers["from"] == ["me@example.com"]
   end
 
   test "address name contains comma" do
@@ -594,7 +610,7 @@ defmodule Mail.Parsers.RFC2822Test do
              "third@example.com"
            ]
 
-    assert message.headers["from"] == {"Lastname, First Names", "me@example.com"}
+    assert message.headers["from"] == [{"Lastname, First Names", "me@example.com"}]
   end
 
   test "address name is an e-mail address with additiongal quotes" do
@@ -607,7 +623,7 @@ defmodule Mail.Parsers.RFC2822Test do
 
       """)
 
-    assert message.headers["from"] == {"\"me@example.com\"", "me@example.com"}
+    assert message.headers["from"] == [{"\"me@example.com\"", "me@example.com"}]
   end
 
   # See https://tools.ietf.org/html/rfc2047
@@ -1012,7 +1028,9 @@ defmodule Mail.Parsers.RFC2822Test do
       From: =?UTF-8?B?am9obi5kb2VAcmVkYWN0ZS4uLg==?= <comments-noreply@docs.google.com>
       """)
 
-    assert message.headers["from"] == {"john.doe@redacte...", "comments-noreply@docs.google.com"}
+    assert message.headers["from"] == [
+             {"john.doe@redacte...", "comments-noreply@docs.google.com"}
+           ]
   end
 
   test "correct handling of encoded words according to RFC 2047 (examples)" do
@@ -1025,7 +1043,7 @@ defmodule Mail.Parsers.RFC2822Test do
        =?ISO-8859-2?B?dSB1bmRlcnN0YW5kIHRoZSBleGFtcGxlLg==?=
       """)
 
-    assert message.headers["from"] == {"Keith Moore", "moore@cs.utk.edu"}
+    assert message.headers["from"] == [{"Keith Moore", "moore@cs.utk.edu"}]
     assert message.headers["to"] == [{"Keld J\xF8rn Simonsen", "keld@dkuug.dk"}]
     assert message.headers["cc"] == [{"Andr\xE9 Pirard", "PIRARD@vm1.ulg.ac.be"}]
     assert message.headers["subject"] == "If you can read this you understand the example."
@@ -1037,7 +1055,7 @@ defmodule Mail.Parsers.RFC2822Test do
       Subject: Time for ISO 10646?
       """)
 
-    assert message.headers["from"] == {"Olle J\xE4rnefors", "ojarnef@admin.kth.se"}
+    assert message.headers["from"] == [{"Olle J\xE4rnefors", "ojarnef@admin.kth.se"}]
     assert message.headers["to"] == ["ietf-822@dimacs.rutgers.edu", "ojarnef@admin.kth.se"]
     assert message.headers["subject"] == "Time for ISO 10646?"
 
@@ -1049,7 +1067,7 @@ defmodule Mail.Parsers.RFC2822Test do
       Subject: Re: RFC-HDR care and feeding
       """)
 
-    assert message.headers["from"] == {"Patrik F\xE4ltstr\xF6m", "paf@nada.kth.se"}
+    assert message.headers["from"] == [{"Patrik F\xE4ltstr\xF6m", "paf@nada.kth.se"}]
     assert message.headers["to"] == [{"Dave Crocker", "dcrocker@mordor.stanford.edu"}]
     assert message.headers["cc"] == ["ietf-822@dimacs.rutgers.edu", "paf@comsol.se"]
     assert message.headers["subject"] == "Re: RFC-HDR care and feeding"
@@ -1065,7 +1083,7 @@ defmodule Mail.Parsers.RFC2822Test do
       Content-type: text/plain; charset=ISO-8859-1
       """)
 
-    assert message.headers["from"] == {"Nathaniel Borenstein", "nsb@thumper.bellcore.com"}
+    assert message.headers["from"] == [{"Nathaniel Borenstein", "nsb@thumper.bellcore.com"}]
 
     assert message.headers["to"] == [
              {"Greg Vaudreuil", "gvaudre@NRI.Reston.VA.US"},


### PR DESCRIPTION
<!--
Thank you for contributing!

Here are a few things that will increase the chance that your pull request will get accepted:
 - Write tests, preferably in a test driven style.
 - Add documentation for the changes you made.
 - Follow our styleguide: https://github.com/dockyard/styleguides
-->

<!-- If this pull request addresses an issue please provide the issue number here -->
Closes # .

## Changes proposed in this pull request
<!-- Please describe here what this pull request changes -->

[The RFC 2822 §3.6.2](https://datatracker.ietf.org/doc/html/rfc2822#section-3.6.2), which the parser adheres to, states:

> The originator fields of a message consist of the from field, the sender field (when applicable), and optionally the reply-to field. The from field consists of the field name "From" and a comma-separated list of one or more mailbox specifications.  If the from field contains more than one mailbox specification in the mailbox-list, then the sender field, containing the field name "Sender" and a single mailbox specification, MUST appear in the message.  In either case, an optional reply-to field MAY also be included, which contains the field name "Reply-To" and a comma-separated list of one or more addresses.

In other words:
- The from and reply-to fields both consist of a comma-separated list of one or more recipients.
- The sender field MUST appear if the from field contains more than one recipient. If present, the sender field contains a single recipient.

Therefore, this change proposes returning all from and reply-to recipients if present, and only the first sender recipient if present.