### PR TITLE
extend header encoding to cover control characters

### DIFF
--- a/lib/mail/renderers/rfc_2822.ex
+++ b/lib/mail/renderers/rfc_2822.ex
@@ -209,21 +209,23 @@ defmodule Mail.Renderers.RFC2822 do
   # As stated at https://datatracker.ietf.org/doc/html/rfc2047#section-2, encoded words must be
   # split in 76 chars including its surroundings and delimmiters.
   # Since enclosing starts with =?UTF-8?Q? and ends with ?=, max length should be 64
-  # Per RFC 2047, encoding is only required for non-ASCII characters.
-  # ASCII-only headers should not be encoded, regardless of length.
-  # Per RFC 2047, ASCII-only headers should not be encoded, regardless of length
+  # Per RFC 2047, encoding is only required for non-ASCII characters and control
+  # characters.  Ordinary ASCII-only headers should not be encoded, regardless of length.
   defp encode_header_value(header_value, :quoted_printable) do
-    if contains_non_ascii?(header_value) do
+    if requires_encoding?(header_value) do
       header_value |> Mail.Encoders.QuotedPrintable.encode(64) |> wrap_encoded_words()
     else
       header_value
     end
   end
 
-  # Check if a string contains any non-ASCII characters (bytes > 0x7F)
-  defp contains_non_ascii?(<<>>), do: false
-  defp contains_non_ascii?(<<byte, _rest::binary>>) when byte > 127, do: true
-  defp contains_non_ascii?(<<_byte, rest::binary>>), do: contains_non_ascii?(rest)
+  # Return true if any characters found that require quoted-printable encoding.
+  # ( >0x7F require escaping (non-ASCII), 0x7F and <0x20 (except \t) are control
+  # characters and also need encoding. )
+  defp requires_encoding?(<<>>), do: false
+  defp requires_encoding?(<<byte, _rest::binary>>) when byte > 126, do: true
+  defp requires_encoding?(<<byte, _rest::binary>>) when byte < 32 and byte != ?\t, do: true
+  defp requires_encoding?(<<_byte, rest::binary>>), do: requires_encoding?(rest)
 
   defp wrap_encoded_words(value) do
     :binary.split(value, "=\r\n", [:global])

--- a/test/mail/renderers/rfc_2822_test.exs
+++ b/test/mail/renderers/rfc_2822_test.exs
@@ -61,6 +61,18 @@ defmodule Mail.Renderers.RFC2822Test do
     assert Mail.Renderers.RFC2822.render_header("Subject", [
              "Hello 世界 World"
            ]) == "Subject: =?UTF-8?Q?Hello =E4=B8=96=E7=95=8C World?="
+
+    assert Mail.Renderers.RFC2822.render_header("Subject", [
+             "normal subject\r\nReply-To: cleverhacker@example.com"
+           ]) == "Subject: =?UTF-8?Q?normal subject=0D=0AReply-To: cleverhacker@example.com?="
+
+    assert Mail.Renderers.RFC2822.render_header("Subject", [
+             "tabs\t\t and  spaces"
+           ]) == "Subject: tabs\t\t and  spaces"
+
+    assert Mail.Renderers.RFC2822.render_header("Subject", [
+             "delete \x7f vertical tab \x0b"
+           ]) == "Subject: =?UTF-8?Q?delete =7F vertical tab =0B?="
   end
 
   test "address headers renders list of recipients" do


### PR DESCRIPTION
```elixir
Mail.build() 
|> Mail.put_from("actualfrom@example.com") 
|> Mail.put_subject("some subject\r\nReply-To: cleverhacker@example.com") 
|> Mail.render() 
|> IO.puts()
```
outputs the following:
```
Subject: some subject
Reply-To: cleverhacker@example.com
From: actualfrom@example.com
```

With this PR applied:
```
Subject: =?UTF-8?Q?some subject=0D=0AReply-To: cleverhacker@example.com?=
From: actualfrom@example.com
```


## Changes proposed in this pull request
Need to encode more than just non-ASCII as control characters can change how a header is read.  People _shouldn't_ be putting in control characters, but it's safer to just encode any that may occur.

This only recently became a problem due to #214 .  Before that, the comparison between encoded and non-encoded would have been false and it would have used the encoded version.
