### PR TITLE
fix(parser): accumulate Authentication-Results headers into a list

### DIFF
--- a/lib/mail/parsers/rfc_2822.ex
+++ b/lib/mail/parsers/rfc_2822.ex
@@ -415,6 +415,9 @@ defmodule Mail.Parsers.RFC2822 do
   defp put_header(headers, "received" = key, value),
     do: Map.update(headers, key, [value], &[value | &1])
 
+  defp put_header(headers, "authentication-results" = key, value),
+    do: Map.update(headers, key, [value], &[value | &1])
+
   defp put_header(headers, key, value),
     do: Map.put(headers, key, value)
 

--- a/lib/mail/parsers/rfc_2822.ex
+++ b/lib/mail/parsers/rfc_2822.ex
@@ -412,10 +412,16 @@ defmodule Mail.Parsers.RFC2822 do
   defp is_params([{_key, _value} | params]), do: is_params(params)
   defp is_params([_ | _]), do: false
 
-  defp put_header(headers, "received" = key, value),
-    do: Map.update(headers, key, [value], &[value | &1])
+  @multi_value_headers ~w(
+    received
+    authentication-results
+    arc-authentication-results
+    arc-seal
+    arc-message-signature
+    dkim-signature
+  )
 
-  defp put_header(headers, "authentication-results" = key, value),
+  defp put_header(headers, key, value) when key in @multi_value_headers,
     do: Map.update(headers, key, [value], &[value | &1])
 
   defp put_header(headers, key, value),

--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -456,8 +456,9 @@ defmodule Mail.Parsers.RFC2822Test do
     assert message.headers["x-received"] ==
              "201.202.203.204 with SMTP id abcdefg.12.123456;        Fri, 01 Apr 2016 11:08:31 -0700 (PDT)"
 
-    assert message.headers["dkim-signature"] ==
+    assert message.headers["dkim-signature"] == [
              "v=1; a=rsa-sha256; c=relaxed/relaxed;        d=example.com; s=20160922;        h=mime-version:in-reply-to:references:date:message-id:subject:from:to;        bh=ABCDEFGHABCDEFGHABCDEFGHABCDEFGHABCDEFGHABC=;        b=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890+/         abcd=="
+           ]
   end
 
   test "parses more than 1 'Received:' header" do
@@ -527,6 +528,79 @@ defmodule Mail.Parsers.RFC2822Test do
     assert message.headers["authentication-results"] == [
              "mx.example.com; spf=pass smtp.mailfrom=sender@example.com"
            ]
+  end
+
+  test "accumulates multiple 'DKIM-Signature' headers into a list" do
+    message =
+      parse_email(~s"""
+      DKIM-Signature: v=1; a=rsa-sha256; d=example.com; s=selector1; b=abc123
+      DKIM-Signature: v=1; a=rsa-sha256; d=forwarder.net; s=selector2; b=def456
+      From: sender@example.com
+      To: recipient@example.com
+      Subject: Test
+      Content-Type: text/plain
+
+      Body
+      """)
+
+    assert message.headers["dkim-signature"] == [
+             "v=1; a=rsa-sha256; d=forwarder.net; s=selector2; b=def456",
+             "v=1; a=rsa-sha256; d=example.com; s=selector1; b=abc123"
+           ]
+  end
+
+  test "accumulates ARC headers into lists" do
+    message =
+      parse_email(~s"""
+      ARC-Seal: i=2; cv=pass; a=rsa-sha256; d=relay.example.net; s=arc; b=seal2
+      ARC-Message-Signature: i=2; a=rsa-sha256; d=relay.example.net; s=arc; b=sig2
+      ARC-Authentication-Results: i=2; relay.example.net; dkim=pass
+      ARC-Seal: i=1; cv=none; a=rsa-sha256; d=origin.example.com; s=arc; b=seal1
+      ARC-Message-Signature: i=1; a=rsa-sha256; d=origin.example.com; s=arc; b=sig1
+      ARC-Authentication-Results: i=1; origin.example.com; spf=pass
+      From: sender@example.com
+      To: recipient@example.com
+      Subject: Test
+      Content-Type: text/plain
+
+      Body
+      """)
+
+    assert message.headers["arc-authentication-results"] == [
+             "i=1; origin.example.com; spf=pass",
+             "i=2; relay.example.net; dkim=pass"
+           ]
+
+    assert message.headers["arc-seal"] == [
+             "i=1; cv=none; a=rsa-sha256; d=origin.example.com; s=arc; b=seal1",
+             "i=2; cv=pass; a=rsa-sha256; d=relay.example.net; s=arc; b=seal2"
+           ]
+
+    assert message.headers["arc-message-signature"] == [
+             "i=1; a=rsa-sha256; d=origin.example.com; s=arc; b=sig1",
+             "i=2; a=rsa-sha256; d=relay.example.net; s=arc; b=sig2"
+           ]
+  end
+
+  test "wraps single ARC and DKIM headers in a list" do
+    message =
+      parse_email(~s"""
+      ARC-Authentication-Results: i=1; mx.example.com; spf=pass
+      ARC-Seal: i=1; cv=none; a=rsa-sha256; b=abc
+      ARC-Message-Signature: i=1; a=rsa-sha256; b=def
+      DKIM-Signature: v=1; a=rsa-sha256; d=example.com; b=ghi
+      From: sender@example.com
+      To: recipient@example.com
+      Subject: Test
+      Content-Type: text/plain
+
+      Body
+      """)
+
+    assert message.headers["arc-authentication-results"] == ["i=1; mx.example.com; spf=pass"]
+    assert message.headers["arc-seal"] == ["i=1; cv=none; a=rsa-sha256; b=abc"]
+    assert message.headers["arc-message-signature"] == ["i=1; a=rsa-sha256; b=def"]
+    assert message.headers["dkim-signature"] == ["v=1; a=rsa-sha256; d=example.com; b=ghi"]
   end
 
   test "parses with a '=' in boundary" do

--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -493,6 +493,42 @@ defmodule Mail.Parsers.RFC2822Test do
            ]
   end
 
+  test "accumulates multiple 'Authentication-Results' headers into a list" do
+    message =
+      parse_email("""
+      Authentication-Results: mx.example.com; spf=pass smtp.mailfrom=sender@example.com
+      Authentication-Results: relay.example.net; dkim=pass header.i=@example.com
+      To: user@example.com
+      From: sender@example.com
+      Subject: Test
+      Content-Type: text/plain
+
+      Test
+      """)
+
+    assert message.headers["authentication-results"] == [
+             "relay.example.net; dkim=pass header.i=@example.com",
+             "mx.example.com; spf=pass smtp.mailfrom=sender@example.com"
+           ]
+  end
+
+  test "wraps a single 'Authentication-Results' header in a list" do
+    message =
+      parse_email("""
+      Authentication-Results: mx.example.com; spf=pass smtp.mailfrom=sender@example.com
+      To: user@example.com
+      From: sender@example.com
+      Subject: Test
+      Content-Type: text/plain
+
+      Test
+      """)
+
+    assert message.headers["authentication-results"] == [
+             "mx.example.com; spf=pass smtp.mailfrom=sender@example.com"
+           ]
+  end
+
   test "parses with a '=' in boundary" do
     message =
       parse_email("""


### PR DESCRIPTION
## Problem
RFC 8601 §2.1 explicitly allows multiple `Authentication-Results` headers (one per MTA hop). Previously, all but the last (least trusted) were silently dropped via `Map.put/3`.

The same issue affects other headers that legitimately appear multiple times:
- ARC-Authentication-Results (RFC 8617 §4.1.1) — one per ARC hop
- ARC-Seal (RFC 8617 §4.1.3) — one per ARC hop
- ARC-Message-Signature (RFC 8617 §4.1.2) — one per ARC hop
- DKIM-Signature (RFC 6376 §3.7) — one per signing domain


## Solution

Introduce a `@multi_value_headers` module attribute and a single `put_header/3` guard clause, replacing the previous per-header clauses for `"received"` and `"authentication-results"` and extending accumulation to the four new headers.

The resulting lists order entries bottom-most first (index 0) and top-most last, so List.last/1 returns the most trusted header per RFC 8601 §4.1.

**Breaking change**: the values at `headers["authentication-results"]`, `headers["dkim-signature"]`, `headers["arc-authentication-results"]`, `headers["arc-seal"]`, and `headers["arc-message-signature"]` change from `binary` to `[binary]`.