### PR TITLE
Add module to handle header encoding and folding

### DIFF
--- a/lib/mail/renderers/rfc_2822.ex
+++ b/lib/mail/renderers/rfc_2822.ex
@@ -1,6 +1,8 @@
 defmodule Mail.Renderers.RFC2822 do
   import Mail.Message, only: [match_content_type?: 2]
 
+  alias Mail.Renderers.RFC2822.HeaderEncoding
+
   @days ~w(Mon Tue Wed Thu Fri Sat Sun)
   @months ~w(Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec)
 
@@ -94,31 +96,39 @@ defmodule Mail.Renderers.RFC2822 do
       |> Enum.map(&String.capitalize(&1))
       |> Enum.join("-")
 
-    key <> ": " <> render_header_value(key, value)
+    prefix = key <> ": "
+    prefix_len = byte_size(prefix)
+    rendered_value = render_header_value(key, value, prefix_len)
+
+    prefix <> HeaderEncoding.fold(rendered_value, prefix_len)
   end
 
-  defp render_header_value("Date", date_time),
+  defp render_header_value(key, value, prefix_len)
+
+  defp render_header_value("Date", date_time, _prefix_len),
     do: timestamp_from_datetime(date_time)
 
-  defp render_header_value(address_type, addresses)
+  defp render_header_value(address_type, addresses, _prefix_len)
        when is_list(addresses) and address_type in @address_types,
        do:
          Enum.map(addresses, &render_address(&1))
          |> Enum.join(", ")
 
-  defp render_header_value(address_type, address) when address_type in @address_types,
-    do: render_address(address)
+  defp render_header_value(address_type, address, _prefix_len)
+       when address_type in @address_types,
+       do: render_address(address)
 
-  defp render_header_value("Content-Transfer-Encoding" = key, value) when is_atom(value) do
+  defp render_header_value("Content-Transfer-Encoding" = key, value, prefix_len)
+       when is_atom(value) do
     value =
       value
       |> Atom.to_string()
       |> String.replace("_", "-")
 
-    render_header_value(key, value)
+    render_header_value(key, value, prefix_len)
   end
 
-  defp render_header_value(header, value)
+  defp render_header_value(header, value, _prefix_len)
        when header in [
               # RFC 5322
               "Message-Id",
@@ -134,12 +144,15 @@ defmodule Mail.Renderers.RFC2822 do
     |> Enum.join(" ")
   end
 
-  defp render_header_value(_key, [value | subtypes]),
-    do:
-      Enum.join([encode_header_value(value, :quoted_printable) | render_subtypes(subtypes)], "; ")
+  defp render_header_value(_key, [value | subtypes], prefix_len) when is_binary(value) do
+    Enum.join(
+      [HeaderEncoding.encode_for_prefix(value, prefix_len) | render_subtypes(subtypes)],
+      "; "
+    )
+  end
 
-  defp render_header_value(key, value),
-    do: render_header_value(key, List.wrap(value))
+  defp render_header_value(key, value, prefix_len),
+    do: render_header_value(key, List.wrap(value), prefix_len)
 
   def validate_address(nil), do: raise(ArgumentError, message: "Email address cannot be nil")
 
@@ -156,10 +169,25 @@ defmodule Mail.Renderers.RFC2822 do
     end
   end
 
-  defp render_address({name, email}),
-    do: "#{encode_header_value(~s("#{name}"), :quoted_printable)} <#{validate_address(email)}>"
+  defp render_address({name, email}) do
+    name = render_display_name(name)
+    "#{name} <#{validate_address(email)}>"
+  end
 
   defp render_address(email), do: validate_address(email)
+
+  # RFC 2047 §5(2) forbids encoded-words inside quoted-strings, and RFC 5322
+  # allows display names to be either an atom phrase or a quoted-string. We
+  # render display names as either a quoted ASCII string or a bare encoded-
+  # word (no surrounding quotes) so the encoded-word remains a recognizable
+  # token to parsers.
+  defp render_display_name(name) when is_binary(name) do
+    if HeaderEncoding.needs_encoding?(name) do
+      HeaderEncoding.encode(name)
+    else
+      ~s("#{name}")
+    end
+  end
 
   defp render_subtypes([]), do: []
 
@@ -172,16 +200,20 @@ defmodule Mail.Renderers.RFC2822 do
 
   defp render_subtypes([{key, value} | subtypes]) do
     key = String.replace(key, "_", "-")
-    value = encode_header_value(value, :quoted_printable)
 
-    value =
-      if value =~ ~r/[\s()<>@,;:\\<\/\[\]?=]/ do
-        "\"#{value}\""
-      else
-        value
+    rendered_value =
+      cond do
+        HeaderEncoding.needs_encoding?(value) ->
+          HeaderEncoding.encode(value)
+
+        value =~ ~r/[\s()<>@,;:\\<\/\[\]?=]/ ->
+          ~s("#{value}")
+
+        true ->
+          value
       end
 
-    ["#{key}=#{value}" | render_subtypes(subtypes)]
+    ["#{key}=#{rendered_value}" | render_subtypes(subtypes)]
   end
 
   @doc """
@@ -204,31 +236,6 @@ defmodule Mail.Renderers.RFC2822 do
     |> Enum.filter(& &1)
     |> Enum.reverse()
     |> Enum.join("\r\n")
-  end
-
-  # As stated at https://datatracker.ietf.org/doc/html/rfc2047#section-2, encoded words must be
-  # split in 76 chars including its surroundings and delimmiters.
-  # Since enclosing starts with =?UTF-8?Q? and ends with ?=, max length should be 64
-  # Per RFC 2047, encoding is only required for non-ASCII characters.
-  # ASCII-only headers should not be encoded, regardless of length.
-  # Per RFC 2047, ASCII-only headers should not be encoded, regardless of length
-  defp encode_header_value(header_value, :quoted_printable) do
-    if contains_non_ascii?(header_value) do
-      header_value |> Mail.Encoders.QuotedPrintable.encode(64) |> wrap_encoded_words()
-    else
-      header_value
-    end
-  end
-
-  # Check if a string contains any non-ASCII characters (bytes > 0x7F)
-  defp contains_non_ascii?(<<>>), do: false
-  defp contains_non_ascii?(<<byte, _rest::binary>>) when byte > 127, do: true
-  defp contains_non_ascii?(<<_byte, rest::binary>>), do: contains_non_ascii?(rest)
-
-  defp wrap_encoded_words(value) do
-    :binary.split(value, "=\r\n", [:global])
-    |> Enum.map(fn chunk -> <<"=?UTF-8?Q?", chunk::binary, "?=">> end)
-    |> Enum.join()
   end
 
   @doc """

--- a/lib/mail/renderers/rfc_2822/header_encoding.ex
+++ b/lib/mail/renderers/rfc_2822/header_encoding.ex
@@ -1,0 +1,259 @@
+defmodule Mail.Renderers.RFC2822.HeaderEncoding do
+  @moduledoc """
+  RFC 2047 encoded-word generation and RFC 5322 header folding.
+
+  This module is used by `Mail.Renderers.RFC2822` to turn header values into
+  spec-compliant physical lines:
+
+    * Non-ASCII values are encoded as one or more `=?UTF-8?Q?...?=` words,
+      split on grapheme cluster boundaries so a multi-octet character can
+      never span two encoded-words (RFC 2047 §5.3).
+    * Adjacent encoded-words are separated by linear white space so that the
+      folding pass can later replace it with `CRLF SPACE` (RFC 2047 §2/§5).
+    * Spaces inside an encoded-word are written as `_` (RFC 2047 §4.2) so
+      the entire word stays an indivisible token to the folder.
+    * Folding inserts `CRLF` before foldable whitespace whenever the next
+      atom would push a physical line past 78 octets (RFC 5322 §2.1.1).
+      Encoded-words are never split.
+  """
+
+  @ew_charset "UTF-8"
+  @ew_encoding "Q"
+  @ew_prefix "=?" <> @ew_charset <> "?" <> @ew_encoding <> "?"
+  @ew_suffix "?="
+
+  # RFC 2047 §2: the whole encoded-word (including delimiters) must be <= 75 octets.
+  @rfc2047_max_word_length 75
+  @ew_overhead byte_size(@ew_prefix) + byte_size(@ew_suffix)
+  @ew_max_payload @rfc2047_max_word_length - @ew_overhead
+
+  # RFC 5322 §2.1.1: lines SHOULD be <= 78 characters (excluding CRLF).
+  @max_line_length 78
+
+  @doc """
+  Encodes `value` per RFC 2047, sizing the first encoded-word so it fits on
+  the same physical line as a header-name prefix of `prefix_len` octets, and
+  sizing subsequent encoded-words so they fit on continuation lines.
+
+  Pure ASCII values are returned unchanged.
+  """
+  @spec encode_for_prefix(binary(), non_neg_integer()) :: binary()
+  def encode_for_prefix(value, prefix_len) when is_binary(value) do
+    if needs_encoding?(value) do
+      encode(value, max(@max_line_length - prefix_len - @ew_overhead, 1))
+    else
+      value
+    end
+  end
+
+  @doc """
+  Returns `true` if `value` contains any octet that is not allowed unencoded in
+  an RFC 5322 header field (i.e. anything outside the printable ASCII range
+  plus horizontal tab).
+  """
+  @spec needs_encoding?(binary()) :: boolean()
+  def needs_encoding?(<<>>), do: false
+  def needs_encoding?(<<?\t, rest::binary>>), do: needs_encoding?(rest)
+  def needs_encoding?(<<b, rest::binary>>) when b in 0x20..0x7E, do: needs_encoding?(rest)
+  def needs_encoding?(<<_, _::binary>>), do: true
+
+  @doc """
+  Encodes a string as one or more RFC 2047 Q encoded-words when it contains
+  characters that require encoding. Pure ASCII strings are returned unchanged.
+
+  Multiple encoded-words are joined by a single SPACE, which is the linear
+  white space mandated between adjacent encoded-words by RFC 2047. The folder
+  may later replace that SPACE with `CRLF SPACE`.
+
+  Encoded-words are split on extended grapheme cluster boundaries so a
+  multi-octet character (including ZWJ sequences) is never divided across two
+  words. If a single grapheme's Q-encoded form is larger than will fit in one
+  encoded-word, `ArgumentError` is raised.
+
+  `first_word_payload` constrains the Q-encoded payload of the first word.
+  Use it when the first physical line must accommodate a header-name prefix
+  (see `encode_for_prefix/2`). Every subsequent word is sized at the standard
+  RFC 2047 maximum of 63 payload octets.
+  """
+  @spec encode(binary(), pos_integer()) :: binary()
+  def encode(value, first_word_payload \\ @ew_max_payload) when is_binary(value) do
+    if needs_encoding?(value) do
+      first_max = clamp_payload(first_word_payload)
+
+      value
+      |> String.graphemes()
+      |> pack_words(first_max, @ew_max_payload, [], <<>>)
+      |> wrap_words()
+    else
+      value
+    end
+  end
+
+  defp clamp_payload(n) when is_integer(n) and n >= 1, do: min(n, @ew_max_payload)
+  defp clamp_payload(_), do: @ew_max_payload
+
+  defp pack_words([], _first, _rest, words, <<>>), do: Enum.reverse(words)
+  defp pack_words([], _first, _rest, words, acc), do: Enum.reverse([acc | words])
+
+  defp pack_words([grapheme | rest], first_max, rest_max, words, acc) do
+    encoded = q_encode_grapheme(grapheme)
+    size = byte_size(encoded)
+    current_max = if words == [], do: first_max, else: rest_max
+
+    cond do
+      size > rest_max ->
+        raise ArgumentError,
+              "grapheme cluster #{inspect(grapheme)} encodes to #{size} bytes, " <>
+                "which exceeds the RFC 2047 maximum encoded-word payload of " <>
+                "#{rest_max} bytes"
+
+      byte_size(acc) + size <= current_max ->
+        pack_words(rest, first_max, rest_max, words, <<acc::binary, encoded::binary>>)
+
+      byte_size(acc) == 0 ->
+        # `current_max` is tighter than `rest_max`; the first word cannot fit
+        # even a single grapheme. Skip the constrained first word and let
+        # this grapheme become the start of the next (full-sized) word. The
+        # caller's first physical line will overflow by a small amount, which
+        # is the documented degraded case for unsplittable atoms.
+        pack_words(rest, rest_max, rest_max, words, encoded)
+
+      true ->
+        pack_words(rest, first_max, rest_max, [acc | words], encoded)
+    end
+  end
+
+  defp q_encode_grapheme(grapheme) when is_binary(grapheme) do
+    for <<byte <- grapheme>>, into: <<>>, do: q_encode_byte(byte)
+  end
+
+  # RFC 2047 §4.2: SPACE may be represented as "_".
+  defp q_encode_byte(?\s), do: "_"
+  # RFC 2047 §4.2: "=", "?", and "_" must always be encoded.
+  defp q_encode_byte(b) when b in [?=, ??, ?_], do: encode_hex(b)
+  # Other printable ASCII may be represented verbatim.
+  defp q_encode_byte(b) when b in 0x21..0x7E, do: <<b>>
+  defp q_encode_byte(b), do: encode_hex(b)
+
+  defp encode_hex(b), do: "=" <> Base.encode16(<<b>>)
+
+  defp wrap_words([]), do: <<>>
+
+  defp wrap_words(payloads) do
+    payloads
+    |> Enum.map(fn payload -> @ew_prefix <> payload <> @ew_suffix end)
+    |> Enum.intersperse(" ")
+    |> IO.iodata_to_binary()
+  end
+
+  @doc """
+  Folds a logical header value into physical lines of at most 78 octets
+  (excluding CRLF), per RFC 5322 §2.1.1.
+
+  The first physical line is assumed to begin with a key prefix of length
+  `prefix_len` (commonly `byte_size("Subject: ")` for the Subject header).
+  Continuation lines start with the foldable whitespace that was already
+  present at the fold point.
+
+  Folding only occurs at runs of `SP` or `HT` outside of `=?...?=` tokens. If
+  the next atom would overflow the line and no foldable whitespace is
+  available on the current line, the line is allowed to overflow rather than
+  splitting an indivisible token.
+  """
+  @spec fold(binary(), non_neg_integer()) :: binary()
+  def fold(value, prefix_len) when is_binary(value) do
+    value
+    |> tokenize()
+    |> place_tokens(prefix_len, @max_line_length)
+    |> emit()
+  end
+
+  defp tokenize(<<>>), do: []
+
+  defp tokenize(value) do
+    ~r/[ \t]+|[^ \t]+/
+    |> Regex.scan(value)
+    |> Enum.map(fn [run] ->
+      case run do
+        <<b, _::binary>> when b in [?\s, ?\t] -> {:wsp, run}
+        _ -> {:text, run}
+      end
+    end)
+  end
+
+  defp place_tokens(tokens, prefix_len, max) do
+    initial = %{
+      current: [],
+      current_count: prefix_len,
+      completed: [],
+      last_wsp_pos: nil
+    }
+
+    state = Enum.reduce(tokens, initial, &place_token(&1, &2, max))
+    Enum.reverse([state.current | state.completed])
+  end
+
+  defp place_token({:wsp, ws} = token, %{current: current, current_count: count} = st, max) do
+    proposed = count + byte_size(ws)
+
+    if proposed > max and current != [] do
+      %{
+        st
+        | current: [token],
+          current_count: byte_size(ws),
+          completed: [current | st.completed],
+          last_wsp_pos: nil
+      }
+    else
+      new_current = current ++ [token]
+
+      %{
+        st
+        | current: new_current,
+          current_count: proposed,
+          last_wsp_pos: length(new_current)
+      }
+    end
+  end
+
+  defp place_token({:text, text} = token, %{current: current, current_count: count} = st, max) do
+    proposed = count + byte_size(text)
+
+    cond do
+      proposed <= max ->
+        %{st | current: current ++ [token], current_count: proposed}
+
+      st.last_wsp_pos != nil ->
+        pos = st.last_wsp_pos - 1
+        before_fold = Enum.take(current, pos)
+        after_fold = Enum.drop(current, pos)
+
+        new_state = %{
+          st
+          | current: after_fold,
+            current_count: total_bytes(after_fold),
+            completed: [before_fold | st.completed],
+            last_wsp_pos: nil
+        }
+
+        place_token(token, new_state, max)
+
+      true ->
+        %{st | current: current ++ [token], current_count: proposed}
+    end
+  end
+
+  defp total_bytes(tokens) do
+    Enum.reduce(tokens, 0, fn {_, bin}, acc -> acc + byte_size(bin) end)
+  end
+
+  defp emit(lines) do
+    lines
+    |> Enum.map(fn tokens ->
+      tokens
+      |> Enum.map(fn {_, bin} -> bin end)
+      |> IO.iodata_to_binary()
+    end)
+    |> Enum.join("\r\n")
+  end
+end

--- a/test/mail/message_test.exs
+++ b/test/mail/message_test.exs
@@ -219,7 +219,9 @@ defmodule Mail.MessageTest do
       |> Mail.put_subject(subject)
       |> Mail.render()
 
-    encoded_subject = "=?UTF-8?Q?" <> Mail.Encoders.QuotedPrintable.encode(subject) <> "?="
+    # Encoded-word uses `_` for spaces (RFC 2047 §4.2) so the entire word
+    # remains an indivisible token to the folder.
+    encoded_subject = "=?UTF-8?Q?test_=C3=BC=C3=A4_test?="
 
     assert String.contains?(txt, encoded_subject)
     assert %Mail.Message{headers: %{"subject" => ^subject}} = Mail.Parsers.RFC2822.parse(txt)
@@ -244,14 +246,16 @@ defmodule Mail.MessageTest do
       |> Mail.put_to(to)
       |> Mail.render()
 
-    encoded_from =
-      ~s(From: =?UTF-8?Q?"#{Mail.Encoders.QuotedPrintable.encode(elem(from, 0))}"?= <#{elem(from, 1)}>)
-
-    encoded_to =
-      ~s(To: =?UTF-8?Q?"#{Mail.Encoders.QuotedPrintable.encode(elem(to, 0))}"?= <#{elem(to, 1)}>)
+    # Per RFC 2047 §5(2), encoded-words MUST NOT appear within a quoted-string;
+    # display names with non-ASCII are rendered as a bare encoded-word.
+    encoded_from = "From: =?UTF-8?Q?Joachim_L=C3=B6w?= <joachim.loew@example.com>"
+    encoded_to = "To: =?UTF-8?Q?Wolfgang_Sch=C3=BCler?= <wolfgang.schueler@example.com>"
 
     assert txt =~ encoded_from
     assert txt =~ encoded_to
+
+    assert %Mail.Message{headers: %{"from" => ^from, "to" => [^to]}} =
+             Mail.Parsers.RFC2822.parse(txt)
   end
 
   test "UTF-8 in other header" do
@@ -281,10 +285,18 @@ defmodule Mail.MessageTest do
       |> Mail.put_subject(subject)
       |> Mail.render()
 
-    encoded_subject =
-      "=?UTF-8?Q?=C3=BCber alles=0Anew =3F=3D line some =D0=BE=D1=87=D0=B5=D0=BD?==?UTF-8?Q?=D1=8C-=D0=BE=D1=87=D0=B5=D0=BD=D1=8C-=D0=BE=D1=87=D0=B5=D0=BD?==?UTF-8?Q?=D1=8C-=D0=BE=D1=87=D0=B5=D0=BD=D1=8C-=D0=BE=D1=87=D0=B5=D0=BD?==?UTF-8?Q?=D1=8C-=D0=BE=D1=87=D0=B5=D0=BD=D1=8C-=D0=BE=D1=87=D0=B5=D0=BD?==?UTF-8?Q?=D1=8C-=D0=BE=D1=87=D0=B5=D0=BD=D1=8C-=D0=BE=D1=87=D0=B5=D0=BD?==?UTF-8?Q?=D1=8C-=D0=BE=D1=87=D0=B5=D0=BD=D1=8C-=D0=BE=D1=87=D0=B5=D0=BD?==?UTF-8?Q?=D1=8C-=D0=BE=D1=87=D0=B5=D0=BD=D1=8C long line?="
-
-    assert String.contains?(txt, encoded_subject)
+    # The encoded value is split across multiple `=?UTF-8?Q?...?=` words,
+    # each <= 75 octets, separated by `\r\n ` so adjacent words are joined
+    # by linear whitespace (RFC 2047 §2/§5). The folded subject still
+    # round-trips through the parser exactly.
     assert %Mail.Message{headers: %{"subject" => ^subject}} = Mail.Parsers.RFC2822.parse(txt)
+
+    for line <- txt |> String.trim_trailing("\r\n\r\n") |> String.split("\r\n") do
+      assert byte_size(line) <= 78,
+             "rendered line exceeds 78 octets: #{inspect(line)}"
+    end
+
+    refute txt =~ ~r/\?==\?UTF-8/,
+           "adjacent encoded-words must be separated by linear whitespace"
   end
 end

--- a/test/mail/renderers/rfc_2822/header_encoding_test.exs
+++ b/test/mail/renderers/rfc_2822/header_encoding_test.exs
@@ -1,0 +1,185 @@
+defmodule Mail.Renderers.RFC2822.HeaderEncodingTest do
+  use ExUnit.Case, async: true
+
+  alias Mail.Renderers.RFC2822.HeaderEncoding
+
+  describe "Physical folding (RFC 5322 obs-fold), ASCII-only unstructured" do
+    test "short value stays on one line" do
+      assert "Hello World" == HeaderEncoding.fold("Hello World", 9)
+    end
+
+    test "long value with spaces folds only at foldable whitespace" do
+      value =
+        "lorem ipsum dolor sit amet consectetur adipiscing elit sed do " <>
+          "eiusmod tempor incididunt ut labore et dolore magna aliqua"
+
+      assert "lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod" <>
+               "" <> "\r\n " <> "" <> "tempor incididunt ut labore et dolore magna aliqua" =
+               HeaderEncoding.fold(value, 9)
+    end
+
+    test "tabs are valid fold whitespace and become the continuation indent" do
+      value =
+        Enum.join(
+          ~w(alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu xi omicron pi rho),
+          "\t"
+        )
+
+      assert "alpha\tbeta\tgamma\tdelta\tepsilon\tzeta\teta\ttheta\tiota\tkappa\tlambda\tmu\tnu" <>
+               "\r\n" <> "\txi\tomicron\tpi\trho" = folded = HeaderEncoding.fold(value, 9)
+
+      assert %Mail.Message{headers: %{"subject" => ^value}} =
+               Mail.Parsers.RFC2822.parse("Subject: " <> folded <> "\r\n\r\n")
+    end
+
+    test "consecutive whitespace runs are preserved verbatim when unfolded" do
+      value = "first  second  third  fourth  fifth  sixth  seventh  eighth  ninth  tenth"
+
+      assert "first  second  third  fourth  fifth  sixth  seventh  eighth  ninth" <>
+               "\r\n" <> "  tenth" =
+               folded = HeaderEncoding.fold(value, 9)
+
+      header = "Subject: " <> folded <> "\r\n\r\n"
+
+      assert %Mail.Message{headers: %{"subject" => ^value}} =
+               Mail.Parsers.RFC2822.parse(header)
+    end
+
+    test "long header name uses the actual prefix length when folding" do
+      value = "alpha beta gamma delta epsilon zeta eta theta iota kappa"
+      prefix = "X-Long-Custom-Header-Name: "
+      prefix_len = byte_size(prefix)
+
+      assert "alpha beta gamma delta epsilon zeta eta theta iota" <>
+               "\r\n" <> " kappa" = folded = HeaderEncoding.fold(value, prefix_len)
+
+      assert %Mail.Message{headers: %{"x-long-custom-header-name" => ^value}} =
+               Mail.Parsers.RFC2822.parse(prefix <> folded <> "\r\n\r\n")
+    end
+
+    test "a single unbreakable ASCII token longer than max overflows" do
+      # No WSP in the value, so no fold point exists — the line is allowed
+      # to exceed 78 octets rather than splitting an indivisible token.
+      value = String.duplicate("a", 100)
+      assert value == HeaderEncoding.fold(value, 9)
+    end
+  end
+
+  describe "RFC 2047 Q encoding and word boundaries" do
+    test "single non-ASCII grapheme produces one encoded-word" do
+      encoded = HeaderEncoding.encode("hi 😀")
+      assert encoded == "=?UTF-8?Q?hi_=F0=9F=98=80?="
+      assert byte_size(encoded) <= 75
+    end
+
+    test "em-dash regression — all UTF-8 bytes of `–` stay in one word" do
+      # Reproduces the regression from RFC 2047 §5(3) described in the plan:
+      # the em-dash's three octets =E2=80=93 must not be split between two
+      # adjacent encoded-words.
+      input = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx em-dash follows: – other text"
+
+      assert "=?UTF-8?Q?xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_em-dash_follows:_?= =?UTF-8?Q?=E2=80=93_other_text?=" ==
+               HeaderEncoding.encode(input)
+    end
+
+    test "a single oversized grapheme cluster raises" do
+      # 256 ZWJ-separated emoji combine into one extended grapheme cluster
+      # whose Q-encoded form (4 octets per emoji + 6 for each ZWJ, all
+      # =HH-escaped) easily exceeds the 63-byte payload limit.
+      oversized = Enum.map_join(1..16, "\u200D", fn _ -> "👨" end)
+
+      assert_raise ArgumentError, ~r/exceeds the RFC 2047 maximum/, fn ->
+        HeaderEncoding.encode(oversized)
+      end
+    end
+
+    test "long non-ASCII run produces multiple encoded-words separated by SPACE" do
+      input = String.duplicate("über ", 30)
+      encoded = HeaderEncoding.encode(input)
+      words = String.split(encoded, " ")
+
+      assert [
+               "=?UTF-8?Q?=C3=BCber_=C3=BCber_=C3=BCber_=C3=BCber_=C3=BCber_=C3=BCber_?=",
+               "=?UTF-8?Q?=C3=BCber_=C3=BCber_=C3=BCber_=C3=BCber_=C3=BCber_=C3=BCber_?=",
+               "=?UTF-8?Q?=C3=BCber_=C3=BCber_=C3=BCber_=C3=BCber_=C3=BCber_=C3=BCber_?=",
+               "=?UTF-8?Q?=C3=BCber_=C3=BCber_=C3=BCber_=C3=BCber_=C3=BCber_=C3=BCber_?=",
+               "=?UTF-8?Q?=C3=BCber_=C3=BCber_=C3=BCber_=C3=BCber_=C3=BCber_=C3=BCber_?="
+             ] == words
+    end
+
+    test "spaces inside the encoded text become `_` and round-trip to spaces" do
+      input = "Café résumé"
+      encoded = HeaderEncoding.encode(input)
+      assert encoded == "=?UTF-8?Q?Caf=C3=A9_r=C3=A9sum=C3=A9?="
+
+      header = "Subject: " <> encoded <> "\r\n\r\n"
+
+      assert %Mail.Message{headers: %{"subject" => ^input}} =
+               Mail.Parsers.RFC2822.parse(header)
+    end
+
+    test "pure ASCII strings pass through unchanged" do
+      text = "Hello World!"
+      assert text == HeaderEncoding.encode(text)
+      text = "plain text 1234 ?@#$%"
+      assert text == HeaderEncoding.encode(text)
+    end
+
+    test "literal `?`, `=`, `_` and control octets are Q-encoded" do
+      assert HeaderEncoding.encode("ü?=_\t") == "=?UTF-8?Q?=C3=BC=3F=3D=5F=09?="
+    end
+  end
+
+  describe "Folding interaction with encoded-words" do
+    test "long encoded value folds between encoded-words, never inside one" do
+      input = String.duplicate("über ", 30)
+      encoded = HeaderEncoding.encode_for_prefix(input, 9)
+
+      assert "=?UTF-8?Q?=C3=BCber_=C3=BCber_=C3=BCber_=C3=BCber_=C3=BCber_=C3=BCb?=" <>
+               "\r\n " <>
+               "=?UTF-8?Q?er_=C3=BCber_=C3=BCber_=C3=BCber_=C3=BCber_=C3=BCber_=C3=BCber_?=" <>
+               "\r\n " <>
+               "=?UTF-8?Q?=C3=BCber_=C3=BCber_=C3=BCber_=C3=BCber_=C3=BCber_=C3=BCber_?=" <>
+               "\r\n " <>
+               "=?UTF-8?Q?=C3=BCber_=C3=BCber_=C3=BCber_=C3=BCber_=C3=BCber_=C3=BCber_?=" <>
+               "\r\n " <>
+               "=?UTF-8?Q?=C3=BCber_=C3=BCber_=C3=BCber_=C3=BCber_=C3=BCber_=C3=BCber_?=" ==
+               HeaderEncoding.fold(encoded, 9)
+    end
+
+    test "a value that fills the first line to exactly 78 octets needs no fold" do
+      # 78 - 9 (prefix "Subject: ") = 69 bytes of content fits without folding.
+      value = String.duplicate("a", 69)
+      folded = HeaderEncoding.fold(value, 9)
+      assert folded == value
+      assert byte_size("Subject: " <> folded) == 78
+    end
+
+    test "embedded LF in the value is preserved via Q-encoding and round-trips" do
+      input = "line one\nline two with über content"
+
+      header =
+        Mail.build()
+        |> Mail.put_subject(input)
+        |> Mail.render()
+
+      assert %Mail.Message{headers: %{"subject" => ^input}} =
+               Mail.Parsers.RFC2822.parse(header)
+    end
+  end
+
+  describe "needs_encoding?/1" do
+    test "false for pure ASCII printable + tab" do
+      refute HeaderEncoding.needs_encoding?("hello world")
+      refute HeaderEncoding.needs_encoding?("tab\there")
+      refute HeaderEncoding.needs_encoding?("special chars ?=_,.;:<>@")
+    end
+
+    test "true for non-ASCII or control octets" do
+      assert HeaderEncoding.needs_encoding?("über")
+      assert HeaderEncoding.needs_encoding?("with\nLF")
+      assert HeaderEncoding.needs_encoding?("with\rCR")
+      assert HeaderEncoding.needs_encoding?("emoji 😀")
+    end
+  end
+end

--- a/test/mail/renderers/rfc_2822_test.exs
+++ b/test/mail/renderers/rfc_2822_test.exs
@@ -52,15 +52,15 @@ defmodule Mail.Renderers.RFC2822Test do
 
     assert Mail.Renderers.RFC2822.render_header("Subject", [
              "Hello World 😀"
-           ]) == "Subject: =?UTF-8?Q?Hello World =F0=9F=98=80?="
+           ]) == "Subject: =?UTF-8?Q?Hello_World_=F0=9F=98=80?="
 
     assert Mail.Renderers.RFC2822.render_header("Subject", [
              "Café résumé"
-           ]) == "Subject: =?UTF-8?Q?Caf=C3=A9 r=C3=A9sum=C3=A9?="
+           ]) == "Subject: =?UTF-8?Q?Caf=C3=A9_r=C3=A9sum=C3=A9?="
 
     assert Mail.Renderers.RFC2822.render_header("Subject", [
              "Hello 世界 World"
-           ]) == "Subject: =?UTF-8?Q?Hello =E4=B8=96=E7=95=8C World?="
+           ]) == "Subject: =?UTF-8?Q?Hello_=E4=B8=96=E7=95=8C_World?="
   end
 
   test "address headers renders list of recipients" do
@@ -158,7 +158,12 @@ defmodule Mail.Renderers.RFC2822Test do
 
     header = Mail.Renderers.RFC2822.render_header("References", message_ids)
 
-    assert header == "References: #{message_ids}"
+    # Each msg-id is > 78 octets so the header is folded between IDs at the
+    # foldable whitespace, but no encoded-word wrapping is introduced.
+    refute header =~ ~r/=\?UTF-8/
+
+    assert %Mail.Message{headers: %{"references" => ^message_ids}} =
+             Mail.Parsers.RFC2822.parse(header <> "\r\n\r\n")
   end
 
   test "headers - renders all headers" do
@@ -309,6 +314,170 @@ defmodule Mail.Renderers.RFC2822Test do
     result = Mail.Renderers.RFC2822.render(message)
 
     assert_rfc2822_equal(result, fixture)
+  end
+
+  describe "header folding" do
+    test "long To list folds after comma boundaries" do
+      addresses =
+        Enum.map(1..5, fn i -> "addr#{i}-with-padding@example.com" end)
+
+      header = Mail.Renderers.RFC2822.render_header("To", addresses)
+      lines = String.split(header, "\r\n")
+
+      assert length(lines) > 1
+
+      for line <- Enum.drop(lines, 1) do
+        assert String.starts_with?(line, " ")
+      end
+
+      for line <- lines do
+        assert byte_size(line) <= 78
+      end
+
+      previous_lines = Enum.drop(lines, -1)
+
+      for line <- previous_lines do
+        assert String.ends_with?(line, ","),
+               "expected folded address-list line to end with a comma, got #{inspect(line)}"
+      end
+    end
+
+    test "comma boundary is preferred over an interior space" do
+      addresses = [
+        {"Some User One", "user1@example.com"},
+        {"Other User Two", "user2@example.com"}
+      ]
+
+      header =
+        Mail.Renderers.RFC2822.render_header(
+          "To",
+          addresses ++
+            Enum.map(3..5, fn i -> "addr#{i}-padded@example.com" end)
+        )
+
+      # Quoted display names contain interior whitespace that *would* be a
+      # valid fold point, but the line should still prefer the comma between
+      # addresses because that comma is the closest fit-rightmost wsp.
+      lines = String.split(header, "\r\n")
+      assert length(lines) > 1
+
+      for line <- Enum.drop(lines, -1) do
+        assert String.ends_with?(line, ","),
+               "expected break after `, ` boundary, got line ending #{inspect(line)}"
+      end
+    end
+
+    test "address with long quoted display name still produces parseable output" do
+      address =
+        {"Some Really Quite Lengthy Display Name For Folding", "long.email.address@example.com"}
+
+      header = Mail.Renderers.RFC2822.render_header("From", address)
+
+      assert %Mail.Message{headers: %{"from" => ^address}} =
+               Mail.Parsers.RFC2822.parse(header <> "\r\n\r\n")
+    end
+
+    test "non-ASCII display name uses a bare encoded-word and round-trips" do
+      from = {"Joachim Löw", "joachim.loew@example.com"}
+      header = Mail.Renderers.RFC2822.render_header("From", from)
+
+      assert header == "From: =?UTF-8?Q?Joachim_L=C3=B6w?= <joachim.loew@example.com>"
+
+      assert %Mail.Message{headers: %{"from" => ^from}} =
+               Mail.Parsers.RFC2822.parse(header <> "\r\n\r\n")
+    end
+
+    test "long Content-Type folds between `; ` parameter boundaries" do
+      header =
+        Mail.Renderers.RFC2822.render_header("Content-Type", [
+          "multipart/mixed",
+          {"boundary", "=Apple-Mail-358A6BE7-EE99-47E3-B9DE-7575E1C181D1="},
+          {"x_long_param_name", "some-long-value-that-keeps-going-and-going"}
+        ])
+
+      lines = String.split(header, "\r\n")
+      assert length(lines) > 1
+
+      for line <- lines do
+        assert byte_size(line) <= 78
+      end
+
+      assert %Mail.Message{
+               headers: %{
+                 "content-type" => [
+                   "multipart/mixed",
+                   {"boundary", "=Apple-Mail-358A6BE7-EE99-47E3-B9DE-7575E1C181D1="},
+                   {"x_long_param_name", "some-long-value-that-keeps-going-and-going"}
+                 ]
+               }
+             } = Mail.Parsers.RFC2822.parse(header <> "\r\n\r\n")
+    end
+
+    test "Content-Disposition with non-ASCII filename uses encoded-word value" do
+      header =
+        Mail.Renderers.RFC2822.render_header("Content-Disposition", [
+          "attachment",
+          filename: "READMEüä.md"
+        ])
+
+      assert header ==
+               "Content-Disposition: attachment; filename==?UTF-8?Q?README=C3=BC=C3=A4.md?="
+
+      assert %Mail.Message{
+               headers: %{
+                 "content-disposition" => ["attachment", {"filename", "READMEüä.md"}]
+               }
+             } = Mail.Parsers.RFC2822.parse(header <> "\r\n\r\n")
+    end
+
+    test "subject round-trips for representative subjects" do
+      cases = [
+        "Hello World!",
+        "Café résumé",
+        "Hello 世界 World",
+        "Hello World 😀",
+        String.duplicate("a", 80),
+        "alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu xi omicron",
+        "über alles\nnew ?= line some очень-очень-очень-очень-очень long line"
+      ]
+
+      for subject <- cases do
+        rendered =
+          Mail.build()
+          |> Mail.put_subject(subject)
+          |> Mail.render()
+
+        assert %Mail.Message{headers: %{"subject" => ^subject}} =
+                 Mail.Parsers.RFC2822.parse(rendered),
+               "round-trip failed for subject #{inspect(subject)}"
+      end
+    end
+
+    test "full message render keeps every header line within the default max" do
+      message =
+        Mail.build_multipart()
+        |> Mail.put_to(Enum.map(1..5, fn i -> "addr#{i}@example.com" end))
+        |> Mail.put_from({"Sender Person", "sender@example.com"})
+        |> Mail.put_subject("Mixed Subject with über and 😀 content")
+        |> Mail.put_text("Body text\r\n")
+        |> Mail.Message.put_content_type("multipart/alternative")
+        |> Mail.Message.put_boundary("boundary-with-a-long-enough-string-12345")
+        |> Mail.Renderers.RFC2822.render()
+
+      [head | _] = String.split(message, "\r\n\r\n", parts: 2)
+
+      for line <- String.split(head, "\r\n") do
+        # Allow a single unbreakable token (e.g. a long boundary value) to
+        # overflow, but only when the line really has no foldable whitespace
+        # other than the leading indent.
+        if byte_size(line) > 78 do
+          stripped = String.trim_leading(line, " ")
+
+          refute String.contains?(stripped, " "),
+                 "line over 78 octets has foldable whitespace: #{inspect(line)}"
+        end
+      end
+    end
   end
 
   test "rendering filters out BCC" do


### PR DESCRIPTION
I’ve extracted the encoding and folding of header values to its own module